### PR TITLE
Remove deprecations-1

### DIFF
--- a/src/Zicht/Bundle/FrameworkExtraBundle/Resources/config/services.xml
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="zicht_embed_helper"/>
             <argument type="service" id="zicht_annotation_registry"/>
             <argument type="service" id="translator"/>
-            <argument type="service" id="security.context" on-invalid="null"/>
+            <argument type="service" id="security.authorization_checker"/>
             <tag name="twig.extension"/>
         </service>
 


### PR DESCRIPTION
- use auth-checker, not security-context
`DEPRECATED - The Symfony\Component\Security\Core\SecurityContext class is deprecated since version 2.6 and will be removed in 3.0. Use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage or Symfony\Component\Security\Core\Authorization\AuthorizationChecker instead.`
http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements

- implement getGlobals interface
`DEPRECATED - Defining the getGlobals() method in the "zicht_framework_extra" extension without explicitly implementing Twig_Extension_GlobalsInterface is deprecated since version 1.23.`