### PR TITLE
Fix bug in parsing uglify config

### DIFF
--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/ZichtFrameworkExtraExtension.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/ZichtFrameworkExtraExtension.php
@@ -41,7 +41,7 @@ class ZichtFrameworkExtraExtension extends DIExtension
         $container->addResource(new FileResource($uglifyConfigFile));
 
         try {
-            $uglifyConfig = Yaml::parse($uglifyConfigFile);
+            $uglifyConfig = Yaml::parse(file_get_contents($uglifyConfigFile));
         } catch (\Exception $e) {
             throw new InvalidConfigurationException(
                 "zicht_framework_extra.uglify setting '$uglifyConfigFile' could not be read",


### PR DESCRIPTION
The current code will lead to errors in Symfony 3.x due to changes in Yaml parsing. This PR supplies a simple fix.

https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#yaml:
> The ability to pass file names to Yaml::parse() has been removed.