### PR TITLE
[ZICHTDEV-1064] zz translations page fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 8.0.6 - 2019-02-01
+### Changed
+- Changed injection of own Translator because of deprecated translator.class parameter
+- Drop false positives in deprecations check and fix depr warning about doctrinedumper
+
 ## 8.0.5 - 2019-01-04
 ### Changed
 - Get Twig extension by FQCN in other Twig Node classes

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/ReplaceTranslatorPass.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/ReplaceTranslatorPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Zicht Online <http://www.zicht.nl>
+ */
+
+namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class ReplaceTranslatorPass
+ */
+class ReplaceTranslatorPass implements CompilerPassInterface
+{
+    /**
+     * Replace the default translator class with our own (if configured) to support `/zz/` browsing
+     * {@inheritdoc}
+     *
+     * @see \Zicht\Bundle\FrameworkExtraBundle\Translation\Translator
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (class_exists(BaseTranslator::class) && $container->hasDefinition('translator.default')
+            && $container->hasParameter('translator.class')) {
+            $class = $container->getParameter('translator.class');
+            $definition = $container->getDefinition('translator.default');
+            $definition->setClass($class);
+        }
+    }
+}

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Resources/config/services.xml
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Resources/config/services.xml
@@ -4,6 +4,7 @@
 
     <parameters>
         <parameter key="zicht_framework_extra.embed_helper.class">Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper</parameter>
+        <parameter key="zicht_framework_extra.translator.class">Zicht\Bundle\FrameworkExtraBundle\Translation\Translator</parameter>
     </parameters>
     <services>
 

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Translation/Translator.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Translation/Translator.php
@@ -10,13 +10,12 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 /**
  * Provides zz locale
  *
- * To enable this feature the default translator class must be replaced by adding the following to config.yml:
- * > parameters:
- * >     translator.class: 'Zicht\Bundle\FrameworkExtraBundle\Translation\Translator'
- *
- * Class Translator
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Translation
+ * @example To enable this feature the default translator class must be replaced by adding the following to config.yml:
+ *          parameters:
+ *              translator.class: 'Zicht\Bundle\FrameworkExtraBundle\Translation\Translator'
+ *          -- or use the param: --
+ *              translator.class: '%zicht_framework_extra.translator.class%'
+ * @see \Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\ReplaceTranslatorPass
  */
 class Translator extends BaseTranslator
 {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/ZichtFrameworkExtraBundle.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/ZichtFrameworkExtraBundle.php
@@ -21,8 +21,9 @@ class ZichtFrameworkExtraBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-        
+
         $container->addCompilerPass(new DependencyInjection\Compiler\RemoveExtensionsPass());
         $container->addCompilerPass(new DependencyInjection\Compiler\FilesystemCacheForceUmaskPass());
+        $container->addCompilerPass(new DependencyInjection\Compiler\ReplaceTranslatorPass());
     }
 }


### PR DESCRIPTION
Changed injection of own Translator because of deprecated `translator.class` parameter