### PR TITLE
Fix dependencies when Doctrine is not installed

### DIFF
--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/RemoveExtensionsPass.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/RemoveExtensionsPass.php
@@ -20,10 +20,6 @@ class RemoveExtensionsPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasExtension('doctrine')) {
-            $container->removeDefinition('zicht_framework_extra.form.zicht_parent_choice_type');
-        }
-
         if (!$container->hasExtension('liip_imagine')) {
             $container->removeDefinition('zicht_framework_extra.imagine.match_filter_loader');
         }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/ZichtFrameworkExtraExtension.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/ZichtFrameworkExtraExtension.php
@@ -111,7 +111,9 @@ class ZichtFrameworkExtraExtension extends DIExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
-        $loader->load('doctrine.xml');
+        if ($container->hasExtension('doctrine')) {
+            $loader->load('doctrine.xml');
+        }
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -123,7 +125,7 @@ class ZichtFrameworkExtraExtension extends DIExtension
 
             $this->addUglifyConfiguration($config['uglify'], $config['uglify_debug'], $container);
         }
-        
+
         if (!empty($config['requirejs'])) {
             if (!isset($config['requirejs_debug'])) {
                 $config['requirejs_debug']= $container->getParameter('kernel.debug');
@@ -131,7 +133,7 @@ class ZichtFrameworkExtraExtension extends DIExtension
 
             $this->addRequirejsConfiguration($config['requirejs'], $config['requirejs_debug'], $container);
         }
-        
+
         if (!empty($config['embed_helper'])) {
             $container->getDefinition('zicht_embed_helper')
                 ->addMethodCall(


### PR DESCRIPTION
On a project where I do not have Doctrine, I'm still getting the error:

> [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
> The service "form.registry" has a dependency on a non-existent service "zicht_framework_extra.form.zicht_parent_choice_type".

Not loading the doctrine dependant services in the first place seems a better solution to me (instead of removing them afterwards)