### PR TITLE
Cleaning up and fixing the bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 vendor
 composer.lock
+.idea/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 8.2.0 - 2020-04-24
+### Fixed
+- Fixed composer.json (psr-4 autoloader, dependencies), fixed linter errors, fixed maintainers
+
 ## 8.1.7 - 2020-01-29
 ### Fixed
 - Fix a bug inside the `EmbedHelper::getFormState` where the variable `$state` is `null` and not an array. 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Provides a set of utilities for use in Symfony projects.
 See the docs in [doc](doc)
 
 # Maintainer
-- Philip Bergman <philip@zicht.nl>
 - Boudewijn Schoon <boudewijn@zicht.nl>
+- Erik Trapman <erik@zicht.nl>

--- a/composer.json
+++ b/composer.json
@@ -16,31 +16,35 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "sonata-project/admin-bundle": "*",
-        "zicht/standards-php": "*@stable"
+        "zicht/standards-php": "^4"
     },
     "autoload": {
-        "psr-0": {
-            "": [
-                "src/"
+        "psr-4": {
+            "Zicht\\Bundle\\FrameworkExtraBundle\\": [
+                "src/Zicht/Bundle/FrameworkExtraBundle/"
             ]
         }
     },
     "autoload-dev": {
-        "psr-0": {
-            "": [
-                "tests/"
+        "psr-4": {
+            "ZichtTest\\Bundle\\FrameworkExtraBundle\\": [
+                "tests/ZichtTest/Bundle/FrameworkExtraBundle/"
             ]
         }
     },
-    "minimum-stability": "stable",
     "license": "MIT",
     "scripts": {
         "lint": [
-            "./vendor/bin/phpcs -s src/Zicht/ --standard=vendor/zicht-standards/php/Zicht --extensions=php"
+            "phpcs --standard=vendor/zicht/standards-php/phpcs.xml src/ tests/"
+        ],
+        "lint-no-warn": [
+            "phpcs -n --standard=vendor/zicht/standards-php/phpcs.xml src/ tests/"
+        ],
+        "lint-fix": [
+            "phpcbf --standard=vendor/zicht/standards-php/phpcs.xml src/ tests/"
         ],
         "test": [
-            "php7.1 ./vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist"
+            "phpunit tests/"
         ]
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,11 +21,4 @@
             </exclude>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-html" target="build/coverage" title="ZichtFrameworkExtraBundle"
-             charset="UTF-8" yui="true" highlight="true"
-             lowUpperBound="35" highLowerBound="70"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
-    </logging>
 </phpunit>

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Admin/TreeAdmin.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Admin/TreeAdmin.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Admin;
 
 use Zicht\Bundle\AdminBundle\Admin\TreeAdmin as BaseTreeAdmin;
 
 /**
- * TreeAdmin
- *
  * @deprecated Use Zicht\Bundle\AdminBundle\Admin\TreeAdmin in stead.
  */
 class TreeAdmin extends BaseTreeAdmin

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Command/AbstractCronCommand.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Command/AbstractCronCommand.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Command;
 
 use Exception;
@@ -23,24 +24,17 @@ use Zicht\Util\Str;
 abstract class AbstractCronCommand extends ContainerAwareCommand
 {
     /**
-     * If the application was neatly cleaned up, this is set to true, and the endOfScript() method will not issue
-     * an error
-     *
-     * @var bool
+     * @var bool If the application was neatly cleaned up, this is set to true, and the endOfScript() method will not issue an error
      */
     private $isFinishedCleanly = false;
 
     /**
-     * Logger instance
-     *
-     * @var \Monolog\Logger
+     * @var Logger
      */
     protected $logger;
 
     /**
-     * Set this to a filename if a mutex should be used.
-     *
-     * @var bool
+     * @var bool Set this to a filename if a mutex should be used.
      */
     protected $mutex = false;
 
@@ -56,10 +50,10 @@ abstract class AbstractCronCommand extends ContainerAwareCommand
     {
         $this->logger = $logger;
         if ($paranoid) {
-            register_shutdown_function(array($this, 'endOfScript'));
+            register_shutdown_function([$this, 'endOfScript']);
         }
-        set_error_handler(array($this, 'errorHandler'));
-        set_exception_handler(array($this, 'exceptionHandler'));
+        set_error_handler([$this, 'errorHandler']);
+        set_exception_handler([$this, 'exceptionHandler']);
 
         if ($verbosity == OutputInterface::VERBOSITY_VERBOSE) {
             $logger->pushHandler(
@@ -85,7 +79,7 @@ abstract class AbstractCronCommand extends ContainerAwareCommand
      */
     public function exceptionHandler(Exception $exception)
     {
-        $this->logger->addError($exception->getMessage(), array($exception->getFile(), $exception->getLine()));
+        $this->logger->addError($exception->getMessage(), [$exception->getFile(), $exception->getLine()]);
         exit(-1);
     }
 
@@ -105,15 +99,15 @@ abstract class AbstractCronCommand extends ContainerAwareCommand
             case E_USER_ERROR:
             case E_ERROR:
             case E_RECOVERABLE_ERROR:
-                $this->logger->addError($errstr, array($file, $line));
+                $this->logger->addError($errstr, [$file, $line]);
                 exit();
                 break;
             case E_WARNING:
             case E_USER_WARNING:
-                $this->logger->addWarning($errstr, array($file, $line));
+                $this->logger->addWarning($errstr, [$file, $line]);
                 break;
             default:
-                $this->logger->addInfo($errstr, array($file, $line));
+                $this->logger->addInfo($errstr, [$file, $line]);
                 break;
         }
     }
@@ -146,8 +140,6 @@ abstract class AbstractCronCommand extends ContainerAwareCommand
 
 
     /**
-     * Run the command.
-     *
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int
@@ -168,7 +160,7 @@ abstract class AbstractCronCommand extends ContainerAwareCommand
                 $isLockAcquired
             );
             if (!$isLockAcquired && $this->logger) {
-                $this->logger->addWarning("Mutex failed in " . get_class($this) . ", job was not run");
+                $this->logger->addWarning('Mutex failed in ' . get_class($this) . ', job was not run');
             }
         } else {
             $result = $this->doParentRun($input, $output);

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Command/ListUserImagesCommand.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Command/ListUserImagesCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Command;
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListUserImagesCommand extends ContainerAwareCommand
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function configure()
     {
@@ -33,7 +33,7 @@ class ListUserImagesCommand extends ContainerAwareCommand
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Command/RepairNestedTreeCommand.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Command/RepairNestedTreeCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Command;
@@ -15,8 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Checks if a NestedTree set is verified (correct), if not repairs the tree
  * using the NestedSet methods.
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Command
  */
 class RepairNestedTreeCommand extends ContainerAwareCommand
 {
@@ -26,7 +24,7 @@ class RepairNestedTreeCommand extends ContainerAwareCommand
     const COMMAND_NAME = 'zicht:repair:nested-tree';
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function configure()
     {
@@ -42,7 +40,7 @@ class RepairNestedTreeCommand extends ContainerAwareCommand
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -54,23 +52,23 @@ class RepairNestedTreeCommand extends ContainerAwareCommand
         if ($repository instanceof NestedTreeRepository) {
             if (true !== ($issues = $repository->verify())) {
                 if ($output->getVerbosity() > 0) {
-                    $output->writeln("Errors found in tree:");
+                    $output->writeln('Errors found in tree:');
                     $output->writeln($formatter->formatBlock($issues, 'comment', true));
                 } else {
-                    $output->writeln("Errors found in tree");
+                    $output->writeln('Errors found in tree');
                 }
                 if ($input->getOption('dry-run')) {
-                    $output->writeln("Dry run, so no changes are made");
+                    $output->writeln('Dry run, so no changes are made');
                 } else {
-                    $output->writeln("Recovering");
+                    $output->writeln('Recovering');
                     $repository->recover();
                     $doctrine->getManager()->flush();
                 }
             } else {
-                $output->writeln("No issues found");
+                $output->writeln('No issues found');
             }
         } else {
-            $output->writeln("Given entity is not of instance NestedTreeRepository");
+            $output->writeln('Given entity is not of instance NestedTreeRepository');
         }
     }
 }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Command/ValidateEntityCommand.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Command/ValidateEntityCommand.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -10,29 +11,22 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 
-
-/**
- * Class ValidateEntityCommand
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Command
- */
 class ValidateEntityCommand extends ContainerAwareCommand
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function configure()
     {
         $this
             ->setName('zicht:entity:validate')
-            ->addArgument('entity', InputArgument::IS_ARRAY|InputArgument::OPTIONAL)
+            ->addArgument('entity', InputArgument::IS_ARRAY | InputArgument::OPTIONAL)
             ->setHelp('This command validates all entities in a repository, useful to test the database for irregularities')
-            ->addOption('group', 'g', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, "Optional validation group(s)")
-        ;
+            ->addOption('group', 'g', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Optional validation group(s)');
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -46,7 +40,7 @@ class ValidateEntityCommand extends ContainerAwareCommand
                 $violations = $this->getContainer()->get('validator')->validate($entity, $groups ? $groups : null);
 
                 if (count($violations)) {
-                    $output->writeln(get_class($entity) . "::" . $entity->getId());
+                    $output->writeln(get_class($entity) . '::' . $entity->getId());
                     foreach ($violations as $error) {
                         $output->writeln(" -> {$error}");
                     }
@@ -56,8 +50,6 @@ class ValidateEntityCommand extends ContainerAwareCommand
     }
 
     /**
-     * get all entities
-     *
      * @return \Generator
      */
     protected function getAllEntities()

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Controller/TranslationController.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Controller/TranslationController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Controller;
@@ -10,11 +10,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * Class TranslationController
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Controller
- */
 class TranslationController extends AbstractController
 {
     /**

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/FilesystemCacheForceUmaskPass.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/FilesystemCacheForceUmaskPass.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class FilesystemCacheForceUmaskPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/RemoveExtensionsPass.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/RemoveExtensionsPass.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
@@ -8,15 +8,10 @@ namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class Pass
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler
- */
 class RemoveExtensionsPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/ReplaceTranslatorPass.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Compiler/ReplaceTranslatorPass.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
@@ -9,14 +9,11 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class ReplaceTranslatorPass
- */
 class ReplaceTranslatorPass implements CompilerPassInterface
 {
     /**
      * Replace the default translator class with our own (if configured) to support `/zz/` browsing
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @see \Zicht\Bundle\FrameworkExtraBundle\Translation\Translator
      */

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Configuration.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection;
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getConfigTreeBuilder()
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/ZichtFrameworkExtraExtension.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/DependencyInjection/ZichtFrameworkExtraExtension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\DependencyInjection;
@@ -20,8 +20,6 @@ use Symfony\Component\Config\Resource\FileResource;
 class ZichtFrameworkExtraExtension extends DIExtension
 {
     /**
-     * Adds the uglify configuration
-     *
      * @param string $uglifyConfigFile
      * @param boolean $isDebug
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
@@ -51,20 +49,18 @@ class ZichtFrameworkExtraExtension extends DIExtension
 
         $global = new Definition(
             'Zicht\Bundle\FrameworkExtraBundle\Twig\UglifyGlobal',
-            array(
+            [
                 $uglifyConfig,
-                $isDebug
-            )
+                $isDebug,
+            ]
         );
 
         $global->addTag('twig.global');
-        $global->addMethodCall('setDebug', array($isDebug));
-        $container->getDefinition('zicht_twig_extension')->addMethodCall('setGlobal', array('zicht_uglify', $global));
+        $global->addMethodCall('setDebug', [$isDebug]);
+        $container->getDefinition('zicht_twig_extension')->addMethodCall('setGlobal', ['zicht_uglify', $global]);
     }
 
     /**
-     * Adds the requirejs configuration
-     *
      * @param string $requirejsConfigFile
      * @param boolean $isDebug
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
@@ -92,19 +88,19 @@ class ZichtFrameworkExtraExtension extends DIExtension
 
         $global = new Definition(
             'Zicht\Bundle\FrameworkExtraBundle\Twig\RequirejsGlobal',
-            array(
+            [
                 $requirejsConfig,
-                $isDebug
-            )
+                $isDebug,
+            ]
         );
 
         $global->addTag('twig.global');
-        $global->addMethodCall('setDebug', array($isDebug));
-        $container->getDefinition('zicht_twig_extension')->addMethodCall('setGlobal', array('zicht_requirejs', $global));
+        $global->addMethodCall('setDebug', [$isDebug]);
+        $container->getDefinition('zicht_twig_extension')->addMethodCall('setGlobal', ['zicht_requirejs', $global]);
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -120,7 +116,7 @@ class ZichtFrameworkExtraExtension extends DIExtension
 
         if (!empty($config['uglify'])) {
             if (!isset($config['uglify_debug'])) {
-                $config['uglify_debug']= $container->getParameter('kernel.debug');
+                $config['uglify_debug'] = $container->getParameter('kernel.debug');
             }
 
             $this->addUglifyConfiguration($config['uglify'], $config['uglify_debug'], $container);
@@ -128,7 +124,7 @@ class ZichtFrameworkExtraExtension extends DIExtension
 
         if (!empty($config['requirejs'])) {
             if (!isset($config['requirejs_debug'])) {
-                $config['requirejs_debug']= $container->getParameter('kernel.debug');
+                $config['requirejs_debug'] = $container->getParameter('kernel.debug');
             }
 
             $this->addRequirejsConfiguration($config['requirejs'], $config['requirejs_debug'], $container);

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/DoctrineQueryPager.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/DoctrineQueryPager.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Doctrine;
 
 use Zicht\Bundle\FrameworkExtraBundle\Pager\Pageable;
@@ -33,8 +34,6 @@ class DoctrineQueryPager implements Pageable
     protected $countQuery;
 
     /**
-     * Constructor.
-     *
      * @param \Doctrine\ORM\QueryBuilder $q
      * @param string $alias
      * @param string $countAlias
@@ -61,7 +60,7 @@ class DoctrineQueryPager implements Pageable
 
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTotal()
     {
@@ -73,7 +72,7 @@ class DoctrineQueryPager implements Pageable
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setRange($start, $length)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/FunctionNode/Rand.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/FunctionNode/Rand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Doctrine\FunctionNode;
@@ -11,15 +11,12 @@ use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
 /**
- * see https://gist.github.com/919465
- */
-/**
- * "RAND" "(" ")"
+ * @deprecated Use https://github.com/beberlei/DoctrineExtensions/blob/master/src/Query/Mysql/Rand.php
  */
 class Rand extends FunctionNode
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function parse(Parser $parser)
     {
@@ -29,7 +26,7 @@ class Rand extends FunctionNode
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSql(SqlWalker $sqlWalker)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/NativeQueryPagable.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/NativeQueryPagable.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Doctrine;
 
 use Pdo;
@@ -9,16 +10,9 @@ use Zicht\Bundle\FrameworkExtraBundle\Pager\Pageable;
 use Doctrine\ORM\NativeQuery;
 use Doctrine\DBAL\Statement;
 
-/**
- * Class NativeQueryPagable
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Doctrine
- */
 class NativeQueryPagable implements Pageable
 {
     /**
-     * NativeQueryPagable constructor.
-     *
      * @param NativeQuery $queryWrapper
      * @param Statement $countQuery
      */
@@ -29,7 +23,7 @@ class NativeQueryPagable implements Pageable
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTotal()
     {
@@ -38,7 +32,7 @@ class NativeQueryPagable implements Pageable
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setRange($start, $length)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/NestedTreeValidationSubscriber.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Doctrine/NestedTreeValidationSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Doctrine;
@@ -34,13 +34,13 @@ class NestedTreeValidationSubscriber implements EventSubscriber
     protected $entityName;
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             'postFlush'
-        );
+        ];
     }
 
     /**

--- a/src/Zicht/Bundle/FrameworkExtraBundle/EventListener/UpdateSchemaDoctrineCommandListener.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/EventListener/UpdateSchemaDoctrineCommandListener.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\EventListener;
@@ -8,9 +8,6 @@ namespace Zicht\Bundle\FrameworkExtraBundle\EventListener;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 
-/**
- * Class UpdateSchemaDoctrineCommandListener
- */
 class UpdateSchemaDoctrineCommandListener
 {
     /**

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Fixture/Builder.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Fixture/Builder.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Fixture;
 
 use Zicht\Util\Str;
@@ -31,8 +32,8 @@ class Builder
     private function __construct($namespaces)
     {
         $this->namespaces = (array)$namespaces;
-        $this->stack    = array();
-        $this->alwaysDo = array();
+        $this->stack = [];
+        $this->alwaysDo = [];
     }
 
 
@@ -44,7 +45,7 @@ class Builder
      */
     public function always($do)
     {
-        $this->alwaysDo[]= $do;
+        $this->alwaysDo[] = $do;
         return $this;
     }
 
@@ -61,7 +62,7 @@ class Builder
     public function __call($method, $args)
     {
         if (method_exists($this->current(), $method)) {
-            call_user_func_array(array($this->current(), $method), $args);
+            call_user_func_array([$this->current(), $method], $args);
         } else {
             $entity = $method;
 
@@ -76,11 +77,11 @@ class Builder
                 $this->push($entityInstance);
             } else {
                 throw new \BadMethodCallException(
-                    "No class found for {$entity} in [" . join(", ", $this->namespaces) . "]"
+                    "No class found for {$entity} in [" . join(', ', $this->namespaces) . ']'
                     . (
-                        $this->current()
-                            ? ", nor is it a method in " . get_class($this->current())
-                            : ""
+                    $this->current()
+                        ? ', nor is it a method in ' . get_class($this->current())
+                        : ''
                     )
                 );
             }
@@ -116,7 +117,7 @@ class Builder
     protected function current()
     {
         if (count($this->stack)) {
-            return $this->stack[count($this->stack) -1];
+            return $this->stack[count($this->stack) - 1];
         }
         return null;
     }
@@ -129,7 +130,7 @@ class Builder
      */
     protected function push($entity)
     {
-        $this->stack[]= $entity;
+        $this->stack[] = $entity;
     }
 
 
@@ -142,7 +143,7 @@ class Builder
     public function end($setter = null)
     {
         if (!count($this->stack)) {
-            throw new \UnexpectedValueException("Stack is empty. Did you call end() too many times?");
+            throw new \UnexpectedValueException('Stack is empty. Did you call end() too many times?');
         }
         $current = array_pop($this->stack);
         if ($parent = $this->current()) {
@@ -151,11 +152,11 @@ class Builder
 
             if ($current instanceof $parentClassName) {
                 if (method_exists($parent, 'addChildren')) {
-                    call_user_func(array($parent, 'addChildren'), $current);
+                    call_user_func([$parent, 'addChildren'], $current);
                 }
             }
             if (is_null($setter)) {
-                foreach (array('set', 'add') as $methodPrefix) {
+                foreach (['set', 'add'] as $methodPrefix) {
                     $methodName = $methodPrefix . $entityLocalName;
 
                     if (method_exists($parent, $methodName)) {
@@ -165,10 +166,10 @@ class Builder
                 }
             }
             if (!is_null($setter)) {
-                call_user_func(array($parent, $setter), $current);
+                call_user_func([$parent, $setter], $current);
             }
 
-            $parentClassNames = array_merge(class_parents($parentClassName), array($parentClassName));
+            $parentClassNames = array_merge(class_parents($parentClassName), [$parentClassName]);
 
             foreach (array_reverse($parentClassNames) as $lParentClassName) {
                 $lParentClass = Str::classname($lParentClassName);
@@ -178,7 +179,7 @@ class Builder
                 }
                 if (method_exists($current, $parentSetter)) {
                     call_user_func(
-                        array($current, $parentSetter),
+                        [$current, $parentSetter],
                         $parent
                     );
                     break;
@@ -205,9 +206,9 @@ class Builder
     {
         $c = count($this->stack);
         if ($c == 0) {
-            throw new \UnexpectedValueException("The stack is empty. You should probably peek() before the last end() call.");
+            throw new \UnexpectedValueException('The stack is empty. You should probably peek() before the last end() call.');
         }
-        $ret = $this->stack[$c -1];
+        $ret = $this->stack[$c - 1];
         return $ret;
     }
 }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Form/MarkupType.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Form/MarkupType.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
@@ -24,13 +25,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *      Use in your form builder like this:
  *
  *           $formMapper->add('teaserExplanation', 'zicht_markup_type', ['inherit_data' => true, 'markup' => 'admin.help.teaser_info'])
- *
- * @package Zicht\Bundle\MokveldSiteBundle\Form\Type
  */
 class MarkupType extends AbstractType
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -39,7 +38,7 @@ class MarkupType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
@@ -48,7 +47,7 @@ class MarkupType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getParent()
     {
@@ -56,15 +55,7 @@ class MarkupType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'zicht_markup_type';
-    }
-
-    /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getBlockPrefix()
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Form/ParentChoiceType.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Form/ParentChoiceType.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Form;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
@@ -26,8 +27,6 @@ class ParentChoiceType extends AbstractType
     protected $doctrine;
 
     /**
-     * Constructs the type.
-     *
      * @param Registry $doctrine
      */
     public function __construct(Registry $doctrine)
@@ -36,24 +35,24 @@ class ParentChoiceType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
-            ->setRequired(array('class'))
+            ->setRequired(['class'])
             ->setDefaults(
-                array(
+                [
                     'data_class' => function (Options $o) {
                         return $o->offsetGet('class');
                     },
                     'required' => false
-                )
+                ]
             );
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -65,7 +64,7 @@ class ParentChoiceType extends AbstractType
         // TODO implement a subscriber for this
         $createParentChoice = function ($parentId) use ($ff, $doctrine, $options) {
             $repo = $doctrine->getRepository($options['class']);
-            $choices = array();
+            $choices = [];
             if (!$parentId) {
                 $list = $repo->getRootNodes();
                 $choices[''] = '';
@@ -75,21 +74,21 @@ class ParentChoiceType extends AbstractType
                 $list = $repo->getChildren($parent, true);
             }
             foreach ($list as $item) {
-                $choices[$item->getId()]= (string)$item;
+                $choices[$item->getId()] = (string)$item;
             }
             return $ff->createNamed(
                 'parent',
                 'choice',
                 $parentId,
-                array('choices' => array_flip($choices), 'mapped' => false, 'auto_initialize' => false)
+                ['choices' => array_flip($choices), 'mapped' => false, 'auto_initialize' => false]
             );
         };
 
         $builder->addEventListener(
             FormEvents::PRE_SUBMIT,
             function ($e) use ($ff, $doctrine, $createParentChoice, $options) {
-                $data     = $e->getData();
-                $form     = $e->getForm();
+                $data = $e->getData();
+                $form = $e->getForm();
                 $parentId = $data['parent'];
                 if (!$parentId) {
                     return;
@@ -117,17 +116,17 @@ class ParentChoiceType extends AbstractType
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
         parent::finishView($view, $form, $options);
         $parent = $form->getData();
-        $view->vars['parents']= array();
+        $view->vars['parents'] = [];
 
         if ($parent) {
             if ($parent->getId()) {
-                $view->vars['parents'][]= $parent;
+                $view->vars['parents'][] = $parent;
             }
             while ($parent = $parent->getParent()) {
                 // Circular reference break
@@ -145,15 +144,7 @@ class ParentChoiceType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'zicht_parent_choice';
-    }
-
-    /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getBlockPrefix()
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Helper/AnnotationRegistry.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Helper/AnnotationRegistry.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Helper;
 
 /**
@@ -12,25 +13,18 @@ namespace Zicht\Bundle\FrameworkExtraBundle\Helper;
 class AnnotationRegistry
 {
     /**
-     * The annotations
-     *
      * @var array
      */
-    private $annotations = array();
+    private $annotations = [];
 
 
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
-        $this->annotations = array();
+        $this->annotations = [];
     }
 
 
     /**
-     * Add an annotation.
-     *
      * @param string $name
      * @param mixed $value
      * @param int $priority
@@ -39,25 +33,23 @@ class AnnotationRegistry
     public function addAnnotation($name, $value, $priority = 0)
     {
         $annotation = $this->getAnnotation($name);
-        $new_annotation = array('name' => $name, 'value' => $value, 'priority' => $priority);
+        $new_annotation = ['name' => $name, 'value' => $value, 'priority' => $priority];
         if (!empty($annotation)) {
             if ($priority > $annotation['value']['priority']) {
                 $this->setAnnotation($annotation['key'], $new_annotation);
             }
         } else {
-            $this->annotations[]= $new_annotation;
+            $this->annotations[] = $new_annotation;
         }
     }
 
     /**
-     * Get annotation
-     *
      * @param string $name
      * @return array
      */
     public function getAnnotation($name)
     {
-        $match = array();
+        $match = [];
         foreach ($this->getAnnotations() as $key => $annotation) {
             if ($annotation['name'] == $name) {
                 $match['key'] = $key;
@@ -68,8 +60,6 @@ class AnnotationRegistry
     }
 
     /**
-     * Set annotation
-     *
      * @param string $key
      * @param string $annotation
      */
@@ -81,8 +71,6 @@ class AnnotationRegistry
     }
 
     /**
-     * Get the annotations.
-     *
      * @return array
      */
     public function getAnnotations()

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Helper/EmbedHelper.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Helper/EmbedHelper.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Helper;
 
 use Symfony\Component\Form\FormError;
@@ -24,9 +25,7 @@ use Zicht\Bundle\FrameworkExtraBundle\Url\UrlCheckerService;
 class EmbedHelper
 {
     /**
-     * Whether or not to consider exceptions thrown by the handler as formerrors.
-     *
-     * @var bool
+     * @var bool Whether or not to consider exceptions thrown by the handler as formerrors.
      */
     protected $isMarkExceptionsAsFormErrors;
 
@@ -51,8 +50,6 @@ class EmbedHelper
     protected $urlChecker;
 
     /**
-     * EmbedHelper constructor.
-     *
      * @param RouterInterface $router
      * @param Session $session
      * @param RequestStack $requestStack
@@ -120,8 +117,8 @@ class EmbedHelper
      * search for a param value in the request stack, start in current
      * and bubble up till master request when not found.
      *
-     * @param bool $checkSafety
      * @param string $name
+     * @param bool $checkSafety
      * @return mixed|null
      */
     protected function getParamFromRequest($name, $checkSafety = true)
@@ -130,11 +127,13 @@ class EmbedHelper
             return $checkSafety ? $this->urlChecker->getSafeUrl($value) : $value;
         }
 
-        if ((null !== $request = $this->requestStack->getParentRequest()) && null !== $value = $request->get($name)) {
+        if ((null !== $request = $this->requestStack->getParentRequest()) && null !== $request->get($name)) {
+            $value = $request->get($name);
             return $checkSafety ? $this->urlChecker->getSafeUrl($value) : $value;
         }
 
-        if ((null !== $request = $this->requestStack->getMasterRequest()) && null !== $value = $request->get($name)) {
+        if ((null !== $request = $this->requestStack->getMasterRequest()) && null !== $request->get($name)) {
+            $value = $request->get($name);
             return $checkSafety ? $this->urlChecker->getSafeUrl($value) : $value;
         }
 
@@ -155,7 +154,7 @@ class EmbedHelper
             // cannot store errors iterator in session because somewhere there is a closure that can't be serialized
             // therefore convert the errors iterator to array, on get from session convert to iterator
             // see [1]
-            $state  = $request->getSession()->get($formId);
+            $state = $request->getSession()->get($formId);
             $state['form_errors'] = (is_array($state) && is_array($state['form_errors'])) ? $state['form_errors'] : [];
             $state['form_errors'] = new FormErrorIterator($form, $state['form_errors']);
         }
@@ -183,8 +182,8 @@ class EmbedHelper
      * @return array|Response
      * @throws \Exception
      */
-    public function handleForm(Form $form, callable $handlerCallback, $formTargetRoute, $formTargetParams = [], $extraViewVars = [], $formIdHandler = null) {
-
+    public function handleForm(Form $form, callable $handlerCallback, $formTargetRoute, $formTargetParams = [], $extraViewVars = [], $formIdHandler = null)
+    {
         $formId = is_callable($formIdHandler) ? $formIdHandler($form) : $this->getFormId($form);
         $request = $this->requestStack->getCurrentRequest();
         $formState = $this->getFormState($form, $formId);
@@ -228,7 +227,7 @@ class EmbedHelper
                         $returnUrl = $successUrl;
 
                         if ($request->isXmlHttpRequest()) {
-                            return new JsonResponse(array('success_url' => $successUrl));
+                            return new JsonResponse(['success_url' => $successUrl]);
                         }
                     } else {
                         // we set a convenience flash message if there was no success url, because
@@ -238,15 +237,15 @@ class EmbedHelper
                 } else {
                     $formStatus = 'errors';
 
-                    $formState['has_errors']  = true;
-                    $formState['data']        = $request->request->get($form->getName());
+                    $formState['has_errors'] = true;
+                    $formState['data'] = $request->request->get($form->getName());
                     $formState['form_errors'] = $form->getErrors();
                 }
             } else {
                 $formStatus = 'errors';
 
-                $formState['has_errors']  = true;
-                $formState['data']        = $request->request->get($form->getName());
+                $formState['has_errors'] = true;
+                $formState['data'] = $request->request->get($form->getName());
                 $formState['form_errors'] = $form->getErrors();
             }
             // redirect to the return url, if available
@@ -302,14 +301,14 @@ class EmbedHelper
 
         if (empty($response)) {
             if ($request->get('extension')) {
-                $formTargetParams += array(
-                    'extension' => $request->get('extension')
-                );
+                $formTargetParams += [
+                    'extension' => $request->get('extension'),
+                ];
             }
             $viewVars['form_status'] = $formStatus;
 
             $viewVars['form_url'] = $this->url($formTargetRoute, $formTargetParams);
-            $viewVars['form']     = $form->createView();
+            $viewVars['form'] = $form->createView();
 
             $prefix = '';
             if ($root = self::getFormRoot($viewVars['form'])) {
@@ -317,9 +316,12 @@ class EmbedHelper
             }
 
             $viewVars['messages'] = [];
-            if ($request->hasPreviousSession() && ($messages = $this->session->getFlashBag()->get($formId))) {
-                foreach ($messages as $value) {
-                    $viewVars['messages'][] = $prefix . $value;
+            if ($request->hasPreviousSession()) {
+                $messages = $this->session->getFlashBag()->get($formId);
+                if ($messages) {
+                    foreach ($messages as $value) {
+                        $viewVars['messages'][] = $prefix . $value;
+                    }
                 }
             }
 
@@ -383,6 +385,7 @@ class EmbedHelper
      *
      * @param Form $form
      * @param string $message
+     * @param SessionInterface|null $session
      */
     public function setFlashMessage(Form $form, $message, SessionInterface $session = null)
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Pager/Pageable.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Pager/Pageable.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Pager;
 
 /**

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Pager/Pager.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Pager/Pager.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Pager;
 
 /**
@@ -9,26 +10,37 @@ namespace Zicht\Bundle\FrameworkExtraBundle\Pager;
  */
 class Pager implements \Iterator, \ArrayAccess, \Countable
 {
-    private $currentPage;
+    /** @var int */
+    private $currentPage = -1;
+
+    /** @var int|null */
     private $total;
-    private $numPages;
-    private $offset;
-    private $lengthOfRange;
-    private $itemsPerPage;
+
+    /** @var int */
+    private $numPages = -1;
+
+    /** @var int */
+    private $offset = -1;
+
+    /** @var int */
+    private $lengthOfRange = -1;
+
+    /** @var int */
+    private $itemsPerPage = -1;
+
+    /** @var Pageable */
     private $results;
 
     /**
-     * Used for iterator implementation
-     *
-     * @var null
+     * @var int|null Used for iterator implementation
      */
-    private $ptr = null;
+    private $ptr;
 
     /**
      * Constructs the pager with the given set of elements to page over, and the given amount of items per page.
      *
-     * @param \Zicht\Bundle\FrameworkExtraBundle\Pager\Pageable $pagable
-     * @param int                                               $itemsPerPage
+     * @param Pageable $pagable
+     * @param int $itemsPerPage
      */
     public function __construct(Pageable $pagable, $itemsPerPage)
     {
@@ -55,7 +67,7 @@ class Pager implements \Iterator, \ArrayAccess, \Countable
     public function setItemsPerPage($itemsPerPage)
     {
         if ($itemsPerPage <= 0) {
-            throw new \InvalidArgumentException("Number of items per page must be positive integer");
+            throw new \InvalidArgumentException('Number of items per page must be positive integer');
         }
         $this->itemsPerPage = $itemsPerPage;
     }
@@ -81,7 +93,7 @@ class Pager implements \Iterator, \ArrayAccess, \Countable
         }
         if ((int)$page != $page) {
             throw new \InvalidArgumentException(
-                "Invalid argument \$page, expected integer number, got " . gettype($page)
+                'Invalid argument $page, expected integer number, got ' . gettype($page)
             );
         }
         $this->numPages = (int)ceil($this->total / $this->itemsPerPage);
@@ -148,7 +160,7 @@ class Pager implements \Iterator, \ArrayAccess, \Countable
      */
     public function getRange()
     {
-        return array($this->getRangeStart(), $this->getRangeEnd());
+        return [$this->getRangeStart(), $this->getRangeEnd()];
     }
 
 
@@ -238,13 +250,13 @@ class Pager implements \Iterator, \ArrayAccess, \Countable
      */
     private function itemAt($i)
     {
-        return array(
+        return [
             'index' => $i,
             'title' => $i + 1,
             'is_previous' => $i == ($this->currentPage - 1),
             'is_current' => $i == $this->currentPage,
             'is_next' => $i == ($this->currentPage + 1)
-        );
+        ];
     }
 
     /**
@@ -379,8 +391,6 @@ class Pager implements \Iterator, \ArrayAccess, \Countable
     }
 
     /**
-     * With gaps
-     *
      * @param int $surround
      * @return array
      */
@@ -397,7 +407,7 @@ class Pager implements \Iterator, \ArrayAccess, \Countable
                 $isPreviousGap = false;
             } elseif (!$isPreviousGap) {
                 $isPreviousGap = true;
-                $ret[$i]= null;
+                $ret[$i] = null;
             }
         }
 

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Resources/translations/messages.nl.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Resources/translations/messages.nl.php
@@ -3,19 +3,19 @@
  * @copyright 2012 Gerard van Helden <http://melp.nl>
  */
 
-return array(
-    '%count% hours ago'     => '%count% uur geleden',
-    '%count% hour ago'      => '%count% uur geleden',
-    '%count% minutes ago'   => '%count% minuten geleden',
-    '%count% minute ago'    => '%count% minuut geleden',
-    '%count% seconds ago'   => '%count% seconden geleden',
-    '%count% second ago'    => '%count% seconde geleden',
-    '%count% years ago'     => '%count% jaar geleden',
-    '%count% year ago'      => '%count% jaar geleden',
-    '%count% weeks ago'     => '%count% weken geleden',
-    '%count% week ago'      => '%count% week geleden',
-    '%count% months ago'    => '%count% maanden geleden',
-    '%count% month ago'     => '%count% maand geleden',
-    '%count% days ago'      => '%count% dagen geleden',
-    '%count% day ago'       => '%count% dag geleden',
-);
+return [
+    '%count% hours ago' => '%count% uur geleden',
+    '%count% hour ago' => '%count% uur geleden',
+    '%count% minutes ago' => '%count% minuten geleden',
+    '%count% minute ago' => '%count% minuut geleden',
+    '%count% seconds ago' => '%count% seconden geleden',
+    '%count% second ago' => '%count% seconde geleden',
+    '%count% years ago' => '%count% jaar geleden',
+    '%count% year ago' => '%count% jaar geleden',
+    '%count% weeks ago' => '%count% weken geleden',
+    '%count% week ago' => '%count% week geleden',
+    '%count% months ago' => '%count% maanden geleden',
+    '%count% month ago' => '%count% maand geleden',
+    '%count% days ago' => '%count% dagen geleden',
+    '%count% day ago' => '%count% dag geleden',
+];

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Translation/Translator.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Translation/Translator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Translation;
@@ -20,9 +20,9 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 class Translator extends BaseTranslator
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
-    public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
+    public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
     {
         if (null === $locale) {
             $locale = $this->getLocale();
@@ -32,10 +32,10 @@ class Translator extends BaseTranslator
             if (null === $domain) {
                 $domain = 'messages';
             }
-            $parts = array(
+            $parts = [
                 sprintf('{%s', $id),
                 sprintf('@%s', $domain),
-            );
+            ];
             if (!empty($parameters)) {
                 $parts [] = json_encode($parameters);
             }
@@ -47,9 +47,9 @@ class Translator extends BaseTranslator
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
+    public function transChoice($id, $number, array $parameters = [], $domain = 'messages', $locale = null)
     {
         if (null === $locale) {
             $locale = $this->getLocale();
@@ -59,11 +59,11 @@ class Translator extends BaseTranslator
             if (null === $domain) {
                 $domain = 'messages';
             }
-            $parts = array(
+            $parts = [
                 sprintf('{%s', $id),
                 sprintf('#%s', $number),
                 sprintf('@%s', $domain),
-            );
+            ];
             if (!empty($parameters)) {
                 $parts [] = sprintf('[%s]', join(', ', array_keys($parameters)));
             }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/StrictNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/StrictNode.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
@@ -18,8 +18,6 @@ use Twig_Compiler;
 class StrictNode extends \Twig_Node
 {
     /**
-     * Compile
-     *
      * @param Twig_Compiler $compiler
      */
     public function compile(Twig_Compiler $compiler)

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/StrictTokenParser.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/StrictTokenParser.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
 
 use Twig_TokenParser;
@@ -13,7 +14,7 @@ use Twig_Token;
 class StrictTokenParser extends Twig_TokenParser
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTag()
     {
@@ -21,7 +22,7 @@ class StrictTokenParser extends Twig_TokenParser
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function parse(Twig_Token $token)
     {
@@ -33,7 +34,7 @@ class StrictTokenParser extends Twig_TokenParser
         $stream = $this->parser->getStream();
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
 
-        $body = $this->parser->subparse(array($this, 'decideEnd'), true);
+        $body = $this->parser->subparse([$this, 'decideEnd'], true);
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
 
         return new StrictNode(['body' => $body, 'expr' => $strictExpr], [], $lineno);
@@ -48,6 +49,6 @@ class StrictTokenParser extends Twig_TokenParser
      */
     public function decideEnd($token)
     {
-        return $token->test(array('endstrict'));
+        return $token->test(['endstrict']);
     }
 }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/SwitchCaseNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/SwitchCaseNode.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
 
 use Twig_Node;
@@ -12,8 +13,6 @@ use Twig_Node;
 class SwitchCaseNode extends Twig_Node
 {
     /**
-     * Constructor
-     *
      * @param array $body
      * @param array $expression
      * @param int $fallthrough
@@ -23,13 +22,13 @@ class SwitchCaseNode extends Twig_Node
     public function __construct($body, $expression, $fallthrough, $lineno = 0, $tag = null)
     {
         parent::__construct(
-            array(
-                'body' => $body
-            ),
-            array(
-                'expression'  => $expression,
-                'fallthrough' => $fallthrough
-            ),
+            [
+                'body' => $body,
+            ],
+            [
+                'expression' => $expression,
+                'fallthrough' => $fallthrough,
+            ],
             $lineno,
             $tag
         );

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/SwitchNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/SwitchNode.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
@@ -15,8 +15,6 @@ use Twig_Compiler;
 class SwitchNode extends Twig_Node
 {
     /**
-     * Constructor
-     *
      * @param \Twig_Node $cases
      * @param \Twig_Node $expression
      * @param int $line
@@ -24,19 +22,17 @@ class SwitchNode extends Twig_Node
     public function __construct(\Twig_Node $cases, \Twig_Node $expression, $line)
     {
         parent::__construct(
-            array(
+            [
                 'expression' => $expression,
                 'cases' => $cases
-            ),
-            array(),
+            ],
+            [],
             $line
         );
     }
 
 
     /**
-     * Compiles the node
-     *
      * @param \Twig_Compiler $compiler
      * @return void
      */

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/SwitchTokenParser.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/SwitchTokenParser.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
 
 use Twig_Error_Syntax;
@@ -9,15 +10,10 @@ use Twig_TokenParser;
 use Twig_Token;
 use Twig_Node;
 
-/**
- * Class SwitchTokenParser
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures
- */
 class SwitchTokenParser extends Twig_TokenParser
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTag()
     {
@@ -25,7 +21,7 @@ class SwitchTokenParser extends Twig_TokenParser
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function parse(Twig_Token $token)
     {
@@ -48,13 +44,13 @@ class SwitchTokenParser extends Twig_TokenParser
         }
         $stream->expect(Twig_Token::BLOCK_START_TYPE);
 
-        $tests = array();
+        $tests = [];
 
         while (!$stream->test('endswitch')) {
-            $token = $stream->expect(Twig_Token::NAME_TYPE, array('case', 'default'));
+            $token = $stream->expect(Twig_Token::NAME_TYPE, ['case', 'default']);
             switch ($token->getValue()) {
                 case 'case':
-                    $caseExpr   = array();
+                    $caseExpr = [];
                     $caseExpr[] = $this->parser->getExpressionParser()->parseExpression();
                     while ($stream->test(Twig_Token::OPERATOR_TYPE, ',')) {
                         $stream->next();
@@ -72,7 +68,7 @@ class SwitchTokenParser extends Twig_TokenParser
                 $fallthrough = true;
             }
             $stream->expect(Twig_Token::BLOCK_END_TYPE);
-            $body = $this->parser->subparse(array($this, 'decideSwitchFork'));
+            $body = $this->parser->subparse([$this, 'decideSwitchFork']);
 
             $tests[] = new SwitchCaseNode(
                 $body,
@@ -98,6 +94,6 @@ class SwitchTokenParser extends Twig_TokenParser
      */
     public function decideSwitchFork($token)
     {
-        return $token->test(array('case', 'default', 'endswitch'));
+        return $token->test(['case', 'default', 'endswitch']);
     }
 }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/WithNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/WithNode.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
@@ -13,8 +13,6 @@ use Twig_Compiler;
 class WithNode extends \Twig_Node
 {
     /**
-     * Constructs the node.
-     *
      * @param array $items
      * @param array $body
      * @param int $options
@@ -24,8 +22,8 @@ class WithNode extends \Twig_Node
     public function __construct($items, $body, $options, $line, $tag)
     {
         parent::__construct(
-            array('body' => $body),
-            array('items' => $items, 'options' => $options),
+            ['body' => $body],
+            ['items' => $items, 'options' => $options],
             $line,
             $tag
         );
@@ -47,8 +45,6 @@ class WithNode extends \Twig_Node
 
 
     /**
-     * Compiles the node.
-     *
      * @param \Twig_Compiler $compiler
      * @return void
      */
@@ -67,7 +63,7 @@ class WithNode extends \Twig_Node
         $compiler->write('$values = array_merge(' . "\n")->indent();
         $i = 0;
         foreach ($this->getAttribute('items') as $argument) {
-            if ($i ++ > 0) {
+            if ($i++ > 0) {
                 $compiler->raw(',' . "\n");
             }
             $this->compileArgument($compiler, $argument);
@@ -104,8 +100,6 @@ class WithNode extends \Twig_Node
 
 
     /**
-     * Compiles the 'with' argument.
-     *
      * @param Twig_Compiler $compiler
      * @param mixed $argument
      * @return void

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/WithTokenParser.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/ControlStructures/WithTokenParser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
@@ -17,11 +17,12 @@ use Twig_NodeInterface;
  */
 class WithTokenParser extends \Twig_TokenParser
 {
-    private $options = array(
+    /** @var string[] */
+    private $options = [
         'merged',
         'sandboxed',
-        'always'
-    );
+        'always',
+    ];
 
     /**
      * Gets the tag name associated with this token parser.
@@ -41,10 +42,10 @@ class WithTokenParser extends \Twig_TokenParser
      */
     public function parse(Twig_Token $token)
     {
-        $options = array();
+        $options = [];
         $stream = $this->parser->getStream();
         $start = $stream->getCurrent();
-        $arguments = array();
+        $arguments = [];
         do {
             $value = $this->parser->getExpressionParser()->parseExpression();
             if ($stream->test('as')) {
@@ -53,7 +54,7 @@ class WithTokenParser extends \Twig_TokenParser
             } else {
                 $name = null;
             }
-            $arguments[] = array('name' => $name, 'value' => $value);
+            $arguments[] = ['name' => $name, 'value' => $value];
 
             $end = !$stream->test(Twig_Token::PUNCTUATION_TYPE, ',');
             if (!$end) {
@@ -66,7 +67,7 @@ class WithTokenParser extends \Twig_TokenParser
         }
 
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
-        $body = $this->parser->subparse(array($this, 'decideWithEnd'), true);
+        $body = $this->parser->subparse([$this, 'decideWithEnd'], true);
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
         return new WithNode($arguments, $body, $options, $start->getLine(), $start->getValue());
     }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/DecoratedRenderNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/DecoratedRenderNode.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig;
 
-use Twig_Compiler;
 use Symfony\Bundle\TwigBundle\Node\RenderNode as BaseRenderNode;
+use Twig_Compiler;
 
 /**
  * This decorator makes sure that if a {% render ... %} is used in Twig, the embed parameters (success_url, return_url)
@@ -17,8 +17,6 @@ use Symfony\Bundle\TwigBundle\Node\RenderNode as BaseRenderNode;
 class DecoratedRenderNode extends \Twig_Node
 {
     /**
-     * DecoratedRenderNode constructor.
-     *
      * @param BaseRenderNode $wrappedNode
      */
     public function __construct(BaseRenderNode $wrappedNode)
@@ -28,8 +26,6 @@ class DecoratedRenderNode extends \Twig_Node
     }
 
     /**
-     * Compile
-     *
      * @param Twig_Compiler $compiler
      */
     public function compile(Twig_Compiler $compiler)

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Extension.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Extension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig;
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\ExpressionBuilder;
-use Symfony\Component\VarDumper\VarDumper;
 use Doctrine\ORM\PersistentCollection;
 use DOMDocument;
 use SimpleXMLElement;
@@ -18,28 +17,25 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\VarDumper\VarDumper;
 use Twig\TwigTest;
 use Zicht\Bundle\FrameworkExtraBundle\Helper\AnnotationRegistry;
 use Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper;
 use Zicht\Util\Debug;
 use Zicht\Util\Str as StrUtil;
 
-/**
- * Class Extension
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig
- */
 class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
-    public static $RELATIVE_DATE_PART_MAP = array(
-        'y' => array('year', 'years'),
-        'm' => array('month', 'months'),
-        'd' => array('day', 'days'),
-        'w' => array('week', 'weeks'),
-        'h' => array('hour', 'hours'),
-        'i' => array('minute', 'minutes'),
-        's' => array('second', 'seconds')
-    );
+    /** @var array<string, string[]>|array[] */
+    public static $RELATIVE_DATE_PART_MAP = [
+        'y' => ['year', 'years'],
+        'm' => ['month', 'months'],
+        'd' => ['day', 'days'],
+        'w' => ['week', 'weeks'],
+        'h' => ['hour', 'hours'],
+        'i' => ['minute', 'minutes'],
+        's' => ['second', 'seconds'],
+    ];
 
     /**
      * @var EmbedHelper
@@ -67,8 +63,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     protected $authChecker;
 
     /**
-     * Extension constructor.
-     *
      * @param EmbedHelper $embedHelper
      * @param AnnotationRegistry $annotationRegistry
      * @param TranslatorInterface|null $translator
@@ -88,8 +82,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Set global
-     *
      * @param string $name
      * @param mixed $value
      */
@@ -99,7 +91,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getGlobals()
     {
@@ -107,53 +99,51 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getFilters()
     {
-        return array(
-            new \Twig_SimpleFilter('dump', array($this, 'dump'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFilter('xml', array($this, 'xml')),
-            new \Twig_SimpleFilter('regex_replace', array($this, 'regexReplace')),
-            new \Twig_SimpleFilter('re_replace', array($this, 'regexReplace')),
-            new \Twig_SimpleFilter('str_uscore', array($this, 'strUscore')),
-            new \Twig_SimpleFilter('str_dash', array($this, 'strDash')),
-            new \Twig_SimpleFilter('str_camel', array($this, 'strCamel')),
-            new \Twig_SimpleFilter('str_humanize', array($this, 'strHumanize')),
-            new \Twig_SimpleFilter('date_format', array($this, 'dateFormat')),
-            new \Twig_SimpleFilter('relative_date', array($this, 'relativeDate')),
-            new \Twig_SimpleFilter('ga_trackevent', array($this, 'gaTrackEvent')),
+        return [
+            new \Twig_SimpleFilter('dump', [$this, 'dump'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFilter('xml', [$this, 'xml']),
+            new \Twig_SimpleFilter('regex_replace', [$this, 'regexReplace']),
+            new \Twig_SimpleFilter('re_replace', [$this, 'regexReplace']),
+            new \Twig_SimpleFilter('str_uscore', [$this, 'strUscore']),
+            new \Twig_SimpleFilter('str_dash', [$this, 'strDash']),
+            new \Twig_SimpleFilter('str_camel', [$this, 'strCamel']),
+            new \Twig_SimpleFilter('str_humanize', [$this, 'strHumanize']),
+            new \Twig_SimpleFilter('date_format', [$this, 'dateFormat']),
+            new \Twig_SimpleFilter('relative_date', [$this, 'relativeDate']),
+            new \Twig_SimpleFilter('ga_trackevent', [$this, 'gaTrackEvent']),
 
-            new \Twig_SimpleFilter('prefix_multiple', array($this, 'prefixMultiple')),
-            new \Twig_SimpleFilter('trans_multiple', array($this, 'transMultiple')),
-            new \Twig_SimpleFilter('truncate_html', array($this, 'truncateHtml')),
+            new \Twig_SimpleFilter('prefix_multiple', [$this, 'prefixMultiple']),
+            new \Twig_SimpleFilter('trans_multiple', [$this, 'transMultiple']),
+            new \Twig_SimpleFilter('truncate_html', [$this, 'truncateHtml']),
 
-            new \Twig_SimpleFilter('with', array($this, 'with')),
-            new \Twig_SimpleFilter('without', array($this, 'without')),
+            new \Twig_SimpleFilter('with', [$this, 'with']),
+            new \Twig_SimpleFilter('without', [$this, 'without']),
 
-            new \Twig_SimpleFilter('where', array($this, 'where')),
-            new \Twig_SimpleFilter('not_where', array($this, 'notWhere')),
-            new \Twig_SimpleFilter('where_split', array($this, 'whereSplit')),
-            new \Twig_SimpleFilter('url_to_form_params', array($this, 'urlToFormParameters')),
-            new \Twig_SimpleFilter('url_strip_query', array($this, 'urlStripQuery')),
+            new \Twig_SimpleFilter('where', [$this, 'where']),
+            new \Twig_SimpleFilter('not_where', [$this, 'notWhere']),
+            new \Twig_SimpleFilter('where_split', [$this, 'whereSplit']),
+            new \Twig_SimpleFilter('url_to_form_params', [$this, 'urlToFormParameters']),
+            new \Twig_SimpleFilter('url_strip_query', [$this, 'urlStripQuery']),
 
             new \Twig_SimpleFilter('ceil', 'ceil'),
             new \Twig_SimpleFilter('floor', 'floor'),
-            new \Twig_SimpleFilter('groups', array($this, 'groups')),
-            new \Twig_SimpleFilter('sort_by_type', array($this, 'sortByType')),
-            new \Twig_SimpleFilter('html2text', array($this, 'htmlToText')),
+            new \Twig_SimpleFilter('groups', [$this, 'groups']),
+            new \Twig_SimpleFilter('sort_by_type', [$this, 'sortByType']),
+            new \Twig_SimpleFilter('html2text', [$this, 'htmlToText']),
             new \Twig_SimpleFilter('replace_recursive', 'array_replace_recursive'),
-            new \Twig_SimpleFilter('json_decode', array($this, 'jsonDecode')),
-            new \Twig_SimpleFilter('sha1', array($this, 'shaOne')),
+            new \Twig_SimpleFilter('json_decode', [$this, 'jsonDecode']),
+            new \Twig_SimpleFilter('sha1', [$this, 'shaOne']),
 
-            new \Twig_SimpleFilter('form_root', array($this, 'formRoot')),
-            new \Twig_SimpleFilter('form_has_errors', array($this, 'formHasErrors')),
-        );
+            new \Twig_SimpleFilter('form_root', [$this, 'formRoot']),
+            new \Twig_SimpleFilter('form_has_errors', [$this, 'formHasErrors']),
+        ];
     }
 
     /**
-     * Prefix multiple
-     *
      * @param array $values
      * @param string $prefix
      * @return \Generator
@@ -303,10 +293,10 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
      */
     public function whereSplit($items, $keyValuePairs)
     {
-        return array(
+        return [
             $this->notWhere($items, $keyValuePairs),
-            $this->where($items, $keyValuePairs)
-        );
+            $this->where($items, $keyValuePairs),
+        ];
     }
 
     /**
@@ -330,15 +320,13 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Url to form parameters
-     *
      * @param string $url
      * @return array
      */
     public function urlToFormParameters($url)
     {
         $query = parse_url($url, PHP_URL_QUERY);
-        $vars = array();
+        $vars = [];
         parse_str($query, $vars);
         return $this->valuesToFormParameters($vars, null);
     }
@@ -352,7 +340,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
      */
     private function valuesToFormParameters($values, $parent)
     {
-        $ret = array();
+        $ret = [];
         foreach ($values as $key => $value) {
             if (null !== $parent) {
                 $keyName = sprintf('%s[%s]', $parent, $key);
@@ -369,18 +357,18 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getFunctions()
     {
-        return array(
+        return [
             'trans_form_errors' => new \Twig_SimpleFunction('trans_form_errors', [$this, 'transFormErrors']),
             'embed_params' => new \Twig_SimpleFunction('embed_params', [$this, 'getEmbedParams']),
             'defaults' => new \Twig_SimpleFunction('defaults', [$this, 'getDefaultOf']),
             'embed' => new \Twig_SimpleFunction('embed', [$this, 'embed']),
             'is_granted' => new \Twig_SimpleFunction('is_granted', [$this, 'isGranted']),
             'embedded_image' => new \Twig_SimpleFunction('embedded_image', [$this, 'embeddedImage']),
-        );
+        ];
     }
 
     /**
@@ -420,8 +408,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Groups
-     *
      * @param array|object $list
      * @param int $numGroups
      * @return array
@@ -430,7 +416,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     {
         $items = ($list instanceof \Traversable ? iterator_to_array($list) : $list);
 
-        $groups = array();
+        $groups = [];
         $i = 0;
         foreach ($items as $item) {
             $groups[$i++ % $numGroups][] = $item;
@@ -456,8 +442,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Sort by type
-     *
      * @param array|object $collection
      * @param array $types
      * @return array
@@ -470,7 +454,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
 
         // store a map of the original sorting, so the usort can use this to keep the original sorting if the types are
         // equal
-        $idToIndexMap = array();
+        $idToIndexMap = [];
         foreach ($collection as $index => $item) {
             $idToIndexMap[$item->getId()] = $index;
         }
@@ -555,8 +539,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Humanize
-     *
      * @param string $str
      * @return string
      */
@@ -566,8 +548,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Format Date
-     *
      * @param string|object|int $date
      * @param string $format
      * @return string
@@ -583,15 +563,13 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
             $ts = new \DateTime($date);
             $ts = $ts->getTimestamp();
         } else {
-            throw new \InvalidArgumentException(sprintf("Cannot format %s as a date", $date));
+            throw new \InvalidArgumentException(sprintf('Cannot format %s as a date', $date));
         }
 
         return strftime($format, $ts);
     }
 
     /**
-     * Relative date
-     *
      * @param string|object $date
      * @return string
      */
@@ -602,7 +580,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
         // natively, diff doesn't contain 'weeks'.
         $diff->w = round($diff->d / 7);
         $message = '';
-        foreach (array('y', 'm', 'w', 'd', 'h', 'i', 's') as $part) {
+        foreach (['y', 'm', 'w', 'd', 'h', 'i', 's'] as $part) {
             if ($diff->$part > 0) {
                 list($singular, $plural) = self::$RELATIVE_DATE_PART_MAP[$part];
                 if ($diff->$part > 1) {
@@ -614,7 +592,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
                 if (null !== $this->translator) {
                     $message = $this->translator->trans(
                         '%count% ' . $denominator . ' ago',
-                        array('%count%' => $diff->$part)
+                        ['%count%' => $diff->$part]
                     );
                 } else {
                     $message = sprintf('%d %s ago', $diff->$part, $denominator);
@@ -676,26 +654,26 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getNodeVisitors()
     {
-        return array(
-            'zicht_render_add_embed_params' => new RenderAddEmbedParamsNodeVisitor()
-        );
+        return [
+            'zicht_render_add_embed_params' => new RenderAddEmbedParamsNodeVisitor(),
+        ];
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTokenParsers()
     {
-        return array(
+        return [
             'zicht_switch' => new ControlStructures\SwitchTokenParser(),
             'zicht_strict' => new ControlStructures\StrictTokenParser(),
             'zicht_meta_annotate' => new Meta\AnnotateTokenParser(),
-            'zicht_meta_annotations' => new Meta\AnnotationsTokenParser()
-        );
+            'zicht_meta_annotations' => new Meta\AnnotationsTokenParser(),
+        ];
     }
 
     /**
@@ -707,8 +685,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Embed
-     *
      * @param array|string $urlOrArray
      * @return array|mixed|string
      */
@@ -723,13 +699,13 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
         } elseif (is_string($urlOrArray)) {
             $query = parse_url($urlOrArray, PHP_URL_QUERY);
             $urlOrArray = str_replace($query, '', $urlOrArray);
-            $currentParams = array();
+            $currentParams = [];
             parse_str($query, $currentParams);
             $currentParams += $embedParams;
 
             return preg_replace('/\?$/', '', $urlOrArray) . '?' . http_build_query($currentParams);
         } else {
-            throw new \InvalidArgumentException("Only supports arrays or strings");
+            throw new \InvalidArgumentException('Only supports arrays or strings');
         }
     }
 
@@ -788,8 +764,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * XML
-     *
      * @param object $data
      * @return string
      */
@@ -816,8 +790,6 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * Transforms errors
-     *
      * @param FormError[] $formErrorList
      * @param string $translationDomain
      * @return array
@@ -832,7 +804,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTests()
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotateNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotateNode.php
@@ -1,23 +1,17 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\Meta;
 
 use Twig_Node;
 use Twig_Compiler;
 use Zicht\Bundle\FrameworkExtraBundle\Twig\Extension as ZichtFrameworkExtraExtension;
 
-/**
- * Class AnnotateNode
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig\Meta
- */
 class AnnotateNode extends Twig_Node
 {
     /**
-     * Compile
-     *
      * @param Twig_Compiler $compiler
      */
     public function compile(Twig_Compiler $compiler)

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotateTokenParser.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotateTokenParser.php
@@ -1,16 +1,12 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\Meta;
 
 use Twig_Token;
 
-/**
- * Class AnnotateTokenParser
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig\Meta
- */
 class AnnotateTokenParser extends \Twig_TokenParser
 {
     /**
@@ -24,16 +20,16 @@ class AnnotateTokenParser extends \Twig_TokenParser
     {
         $stream = $this->parser->getStream();
 
-        $info = array();
+        $info = [];
         $first = $this->parser->getExpressionParser()->parseExpression();
 
         if ($stream->test(Twig_Token::BLOCK_END_TYPE)) {
-            $info['expr']= $first;
+            $info['expr'] = $first;
         } else {
-            $info['name']= $first;
-            $info['expr']= $this->parser->getExpressionParser()->parseExpression();
+            $info['name'] = $first;
+            $info['expr'] = $this->parser->getExpressionParser()->parseExpression();
             if (!$stream->test(Twig_Token::BLOCK_END_TYPE)) {
-                $info['prio']= $this->parser->getExpressionParser()->parseExpression();
+                $info['prio'] = $this->parser->getExpressionParser()->parseExpression();
             }
         }
 

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotationsNode.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotationsNode.php
@@ -2,20 +2,16 @@
 /**
  * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\Meta;
 
 use Twig_Node;
 use Twig_Compiler;
 use Zicht\Bundle\FrameworkExtraBundle\Twig\Extension as ZichtFrameworkExtraExtension;
 
-/**
- * Class AnnotationsNode
- */
 class AnnotationsNode extends Twig_Node
 {
     /**
-     * Compile
-     *
      * @param Twig_Compiler $compiler
      */
     public function compile(Twig_Compiler $compiler)

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotationsTokenParser.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/Meta/AnnotationsTokenParser.php
@@ -1,16 +1,12 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\Meta;
 
 use Twig_Token;
 
-/**
- * Class AnnotationsTokenParser
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig\Meta
- */
 class AnnotationsTokenParser extends \Twig_TokenParser
 {
     /**
@@ -25,11 +21,11 @@ class AnnotationsTokenParser extends \Twig_TokenParser
         $stream = $this->parser->getStream();
 
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
-        $body = $this->parser->subparse(array($this, 'decideEndAnnotations'));
+        $body = $this->parser->subparse([$this, 'decideEndAnnotations']);
         $stream->expect('endannotations');
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
 
-        return new AnnotationsNode(array('body' => $body));
+        return new AnnotationsNode(['body' => $body]);
     }
 
     /**
@@ -43,8 +39,6 @@ class AnnotationsTokenParser extends \Twig_TokenParser
     }
 
     /**
-     * Decide end annotations
-     *
      * @param string $token
      * @return mixed
      */

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/RenderAddEmbedParamsNodeVisitor.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/RenderAddEmbedParamsNodeVisitor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig;
@@ -9,15 +9,10 @@ use Twig_NodeVisitorInterface;
 use Twig_NodeInterface;
 use Twig_Environment;
 
-/**
- * Class RenderAddEmbedParamsNodeVisitor
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig
- */
 class RenderAddEmbedParamsNodeVisitor implements Twig_NodeVisitorInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function enterNode(\Twig_Node $node, Twig_Environment $env)
     {
@@ -25,7 +20,7 @@ class RenderAddEmbedParamsNodeVisitor implements Twig_NodeVisitorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function leaveNode(\Twig_Node $node, Twig_Environment $env)
     {
@@ -33,13 +28,13 @@ class RenderAddEmbedParamsNodeVisitor implements Twig_NodeVisitorInterface
             if ($node->getAttribute('name') === 'controller') {
                 $args = $node->getNode('arguments');
                 if (!$args->hasNode(1)) {
-                    $args->setNode(1, new \Twig_Node_Expression_Array(array(), $node->getTemplateLine()));
+                    $args->setNode(1, new \Twig_Node_Expression_Array([], $node->getTemplateLine()));
                 }
                 $args->setNode(
                     1,
                     new \Twig_Node_Expression_Function(
                         'embed',
-                        new \Twig_Node(array($args->getNode(1))),
+                        new \Twig_Node([$args->getNode(1)]),
                         $node->getTemplateLine()
                     )
                 );
@@ -49,7 +44,7 @@ class RenderAddEmbedParamsNodeVisitor implements Twig_NodeVisitorInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getPriority()
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/RequirejsGlobal.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/RequirejsGlobal.php
@@ -1,21 +1,16 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig;
 
 /**
- * Class RequirejsGlobal
  * Helper twig global for zicht_requirejs configuration
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Twig
  */
 class RequirejsGlobal
 {
     /**
-     * Constructor
-     *
      * @param array $config
      * @param bool $debug
      */

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Twig/UglifyGlobal.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Twig/UglifyGlobal.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig;
@@ -11,8 +11,6 @@ namespace Zicht\Bundle\FrameworkExtraBundle\Twig;
 class UglifyGlobal implements \ArrayAccess, \IteratorAggregate
 {
     /**
-     * Constructor
-     *
      * @param array $config
      * @param bool $debug
      */
@@ -60,7 +58,7 @@ class UglifyGlobal implements \ArrayAccess, \IteratorAggregate
 
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function offsetExists($offset)
     {
@@ -68,22 +66,22 @@ class UglifyGlobal implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function offsetGet($offset)
     {
         if ($this->debug) {
             return array_map(
-                array($this, 'getSourceFile'),
+                [$this, 'getSourceFile'],
                 $this->config['resources'][$offset]['files']
             );
         } else {
-            return array($this->getTargetFile($offset));
+            return [$this->getTargetFile($offset)];
         }
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function offsetSet($offset, $value)
     {
@@ -91,7 +89,7 @@ class UglifyGlobal implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function offsetUnset($offset)
     {
@@ -99,11 +97,11 @@ class UglifyGlobal implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getIterator()
     {
-        $ret = array();
+        $ret = [];
         foreach (array_keys($this->config['resources']) as $key) {
             $ret[$key] = $this[$key];
         }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Url/UrlCheckerService.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Url/UrlCheckerService.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Url;

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Util/SortedList.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Util/SortedList.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Util;
@@ -14,7 +14,8 @@ use IteratorAggregate;
  */
 class SortedList implements IteratorAggregate
 {
-    protected $items = array();
+    /** @var array */
+    protected $items = [];
 
     /**
      * Add an item with the specified priority.
@@ -25,15 +26,13 @@ class SortedList implements IteratorAggregate
      */
     public function insert($item, $priority)
     {
-        $this->items[] = array($priority, $item);
+        $this->items[] = [$priority, $item];
 
         $this->sort();
     }
 
 
     /**
-     * Sort the list.
-     *
      * @return void
      */
     public function sort()
@@ -50,7 +49,7 @@ class SortedList implements IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getIterator()
     {

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Util/SortedSet.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Util/SortedSet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Util;
@@ -16,9 +16,7 @@ namespace Zicht\Bundle\FrameworkExtraBundle\Util;
 class SortedSet implements \Countable
 {
     /**
-     * The set values
-     *
-     * @var array
+     * @var array The set values
      */
     private $values;
 
@@ -28,7 +26,7 @@ class SortedSet implements \Countable
      *
      * @param array $values
      */
-    public function __construct(array $values = array())
+    public function __construct(array $values = [])
     {
         $this->setValues($values);
     }
@@ -42,7 +40,7 @@ class SortedSet implements \Countable
      */
     public function setValues($values)
     {
-        $this->values = array();
+        $this->values = [];
         $this->addValues($values);
     }
 

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Util/SortedSetMap.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Util/SortedSetMap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Util;
@@ -23,7 +23,7 @@ class SortedSetMap
      *
      * @param array $values
      */
-    public function __construct($values = array())
+    public function __construct($values = [])
     {
         $this->setValues($values);
     }
@@ -37,7 +37,7 @@ class SortedSetMap
      */
     public function setValues($values)
     {
-        $this->values = array();
+        $this->values = [];
         foreach ($values as $key => $value) {
             $this->replace($key, (array)$value);
         }
@@ -88,7 +88,7 @@ class SortedSetMap
             return $this->values[$key]->toArray();
         }
 
-        return array();
+        return [];
     }
 
 
@@ -190,7 +190,7 @@ class SortedSetMap
      */
     public function toArray()
     {
-        $ret = array();
+        $ret = [];
         foreach (array_keys($this->values) as $key) {
             $ret[$key] = $this->get($key);
         }

--- a/src/Zicht/Bundle/FrameworkExtraBundle/Validator/ParentValidator.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/Validator/ParentValidator.php
@@ -1,17 +1,12 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Validator;
 
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-/**
- * Class ParentValidator
- *
- * @package Zicht\Bundle\FrameworkExtraBundle\Validator
- */
 class ParentValidator
 {
     /**

--- a/src/Zicht/Bundle/FrameworkExtraBundle/ZichtFrameworkExtraBundle.php
+++ b/src/Zicht/Bundle/FrameworkExtraBundle/ZichtFrameworkExtraBundle.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\FrameworkExtraBundle;
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class ZichtFrameworkExtraBundle extends Bundle
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function build(ContainerBuilder $container)
     {

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Fixture/BuilderTest.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Fixture/BuilderTest.php
@@ -1,8 +1,11 @@
 <?php
+// phpcs:ignoreFile
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
+
     use Zicht\Bundle\FrameworkExtraBundle\Fixture\Builder;
 
     class BuilderTest extends \PHPUnit_Framework_TestCase
@@ -11,10 +14,10 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
 
         function setUp()
         {
-            $this->builder = Builder::create(array('ZichtTest\Bundle\FrameworkExtraBundle\Fixture\Assets'));
+            $this->builder = Builder::create(['ZichtTest\Bundle\FrameworkExtraBundle\Fixture\Assets']);
         }
 
-        function testBuilderCallsSetterOnEnd()
+        public function testBuilderCallsSetterOnEnd()
         {
             $a = $this->builder->A()->B()->end()->peek();
 
@@ -23,7 +26,7 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
         }
 
 
-        function testBuilderCallsParentSetterOnEnd()
+        public function testBuilderCallsParentSetterOnEnd()
         {
             $a = $this->builder->A()->B()->end()->peek();
 
@@ -32,7 +35,7 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
         }
 
 
-        function testBuilderCallsChildAdder()
+        public function testBuilderCallsChildAdder()
         {
             $a = $this->builder->A()->A()->end()->peek();
             $this->assertGreaterThan(0, count($a->children));
@@ -41,14 +44,14 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
             $this->assertInstanceOf('ZichtTest\Bundle\FrameworkExtraBundle\Fixture\Assets\A', $child);
         }
 
-        function testCustomSetter()
+        public function testCustomSetter()
         {
             $a = $this->builder->A()->B()->end('customSetter')->peek();
             $this->assertInstanceOf('ZichtTest\Bundle\FrameworkExtraBundle\Fixture\Assets\B', $a->customSet);
         }
 
 
-        function testBuilderCallsSetParentIfSameClass()
+        public function testBuilderCallsSetParentIfSameClass()
         {
             $a = $this->builder->A()->A()->end()->peek();
             $this->assertGreaterThan(0, count($a->children));
@@ -58,19 +61,19 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
         }
 
 
-
-        function testCallerIsAlwaysCalled()
+        public function testCallerIsAlwaysCalled()
         {
-            $calls = array();
-            $this->builder->always(function($obj) use(&$calls) {
-                $calls[spl_object_hash($obj)]= $obj;
+            $calls = [];
+            $this->builder->always(function ($obj) use (&$calls) {
+                $calls[spl_object_hash($obj)] = $obj;
             });
             $this->builder->A()->A()->end()->end();
             $this->assertEquals(2, count($calls));
         }
 
 
-        function testMethodCall() {
+        public function testMethodCall()
+        {
             $a = $this->builder->A()->setSomething('foo')->peek();
             $this->assertEquals('foo', $a->getSomething());
         }
@@ -79,7 +82,8 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
         /**
          * @expectedException \BadMethodCallException
          */
-        function testBadMethodCall() {
+        public function testBadMethodCall()
+        {
             $this->builder->A()->setSomethingElse('foo');
         }
 
@@ -87,60 +91,71 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
         /**
          * @expectedException \UnexpectedValueException
          */
-        function testEmptyStack() {
+        public function testEmptyStack()
+        {
             $this->builder->A()->end()->end();
         }
 
         /**
          * @expectedException \UnexpectedValueException
          */
-        function testEmptyStackPeek() {
+        public function testEmptyStackPeek()
+        {
             $this->builder->A()->end()->peek();
         }
     }
 }
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture\Assets {
-    class A {
+    class A
+    {
         public $b;
         public $children;
         public $parent;
         public $something;
 
-        function addB(B $b) {
-            $this->b[]= $b;
+        function addB(B $b)
+        {
+            $this->b[] = $b;
         }
 
 
-        function addChildren(A $a) {
-            $this->children[]= $a;
+        function addChildren(A $a)
+        {
+            $this->children[] = $a;
         }
 
 
-        function setParent(A $a) {
+        function setParent(A $a)
+        {
             $this->parent = $a;
         }
 
 
-        function customSetter(B $b) {
+        function customSetter(B $b)
+        {
             $this->customSet = $b;
         }
 
 
-        function setSomething($something) {
+        function setSomething($something)
+        {
             $this->something = $something;
         }
 
 
-        function getSomething() {
+        function getSomething()
+        {
             return $this->something;
         }
     }
 
-    class B {
+    class B
+    {
         public $a;
 
-        function setA(A $a) {
+        function setA(A $a)
+        {
             $this->a = $a;
         }
     }

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Helper/EmbedHelperHandleFormTest.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Helper/EmbedHelperHandleFormTest.php
@@ -1,21 +1,24 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Helper;
 
-use Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper;
-use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Routing\Router as RouterAlias;
 
 /**
  * @covers \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::handleForm
  */
 class EmbedHelperHandleFormTest extends EmbedHelperTest
 {
+    /** @var Form */
     protected $form;
-    protected $router;
 
+    /** @var RouterAlias */
+    protected $router;
 
     /**
      * @return void
@@ -41,7 +44,7 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
         $this->request->getCurrentRequest()->request->set('return_url', 'return url value');
         $this->request->getCurrentRequest()->request->set('success_url', 'success url value');
         $this->router->expects($this->once())->method('generate')
-            ->with('user_login', array('return_url' => 'return url value', 'success_url' => 'success url value'))
+            ->with('user_login', ['return_url' => 'return url value', 'success_url' => 'success url value'])
             ->will(
                 $this->returnCallback(
                     function ($route, $params) {
@@ -67,7 +70,7 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     public function testHandleFormWillStoreFormStateIfNotXmlHttpRequest()
     {
         $this->request->getCurrentRequest()->setMethod('POST');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
         $this->helper->handleForm(
             $this->form,
             function () {
@@ -85,10 +88,14 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     {
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->request->getCurrentRequest()->headers->set('X-Requested-With', 'XMLHttpRequest');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
-        $this->helper->handleForm($this->form, function () {
-            return false;
-        }, 'user_login');
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
+        $this->helper->handleForm(
+            $this->form,
+            function () {
+                return false;
+            },
+            'user_login'
+        );
 
         $this->assertTrue($this->request->getCurrentRequest()->isXmlHttpRequest());
         $this->assertNull($this->session->get($this->helper->getFormId($this->form)));
@@ -101,11 +108,11 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     public function testHandleFormStateWillContainErrorsIfAddedByCallback()
     {
         $this->request->getCurrentRequest()->setMethod('POST');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
         $this->form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $error = new \Symfony\Component\Form\FormError('FooBar');
+        $error = new FormError('FooBar');
         $this->form->expects($this->once())->method('addError');
-        $this->form->expects($this->once())->method('getErrors')->will($this->returnValue(array($error)));
+        $this->form->expects($this->once())->method('getErrors')->will($this->returnValue([$error]));
         $this->form->expects($this->any())->method('getName')->will($this->returnValue('mock'));
 
         $this->helper->handleForm(
@@ -124,7 +131,6 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
         $this->assertEquals('321', $state['data']['foo']);
     }
 
-
     /**
      * @return void
      */
@@ -132,7 +138,7 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     {
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->request->getCurrentRequest()->query->set('return_url', 'return url');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
         $this->form->expects($this->once())->method('isValid')->will($this->returnValue(true));
 
         $response = $this->helper->handleForm(
@@ -147,7 +153,6 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
         $this->assertEmpty($this->session->get($this->helper->getFormId($this->form)));
     }
 
-
     /**
      * @return void
      */
@@ -155,7 +160,7 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     {
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->request->getCurrentRequest()->request->set('return_url', 'return url');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
         $this->form->expects($this->any())->method('getName')->will($this->returnValue('mock'));
         $response = $this->helper->handleForm(
             $this->form,
@@ -169,7 +174,6 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
         $this->assertNotEmpty($this->session->get($this->helper->getFormId($this->form)));
     }
 
-
     /**
      * @return void
      */
@@ -178,7 +182,7 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->request->getCurrentRequest()->query->set('return_url', 'return url');
         $this->request->getCurrentRequest()->headers->set('X-Requested-With', 'XMLHttpRequest');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
         $response = $this->helper->handleForm(
             $this->form,
             function ($form) {
@@ -190,7 +194,6 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
         $this->assertNotInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
     }
 
-
     /**
      * @return void
      */
@@ -198,7 +201,7 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     {
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->request->getCurrentRequest()->query->set('success_url', 'success url');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
         $this->request->getCurrentRequest()->headers->set('X-Requested-With', 'XMLHttpRequest');
         $this->form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $response = $this->helper->handleForm(
@@ -217,34 +220,42 @@ class EmbedHelperHandleFormTest extends EmbedHelperTest
     public function testExceptionHandlingWillThrowExceptionIfNotMarkedAsError()
     {
         $this->request->getCurrentRequest()->setMethod('POST');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
 
         $this->helper->setMarkExceptionsAsFormErrors(false);
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $this->form->expects($this->never())->method('addError');
-        $this->helper->handleForm($this->form, function () {
-            throw new \Exception("foo");
-        }, '');
+        $this->helper->handleForm(
+            $this->form,
+            function () {
+                throw new \Exception('foo');
+            },
+            ''
+        );
     }
 
-    /**
-     */
     public function testExceptionHandlingWillNotThrowExceptionIfNotMarkedAsError()
     {
         $this->request->getCurrentRequest()->setMethod('POST');
-        $this->request->getCurrentRequest()->request->set('mock', array('foo' => '321'));
+        $this->request->getCurrentRequest()->request->set('mock', ['foo' => '321']);
 
         $this->helper->setMarkExceptionsAsFormErrors(true);
         $this->request->getCurrentRequest()->setMethod('POST');
         $this->form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $errors = array();
-        $this->form->expects($this->once())->method('addError')->will($this->returnCallback(function ($e) use (&$errors) {
-            $errors[] = $e;
-        }));
-        $this->helper->handleForm($this->form, function () {
-            throw new \Exception("foo");
-        }, '');
+        $errors = [];
+        $this->form->expects($this->once())->method('addError')->will(
+            $this->returnCallback(function ($e) use (&$errors) {
+                $errors[] = $e;
+            })
+        );
+        $this->helper->handleForm(
+            $this->form,
+            function () {
+                throw new \Exception('foo');
+            },
+            ''
+        );
 
         $this->assertInstanceOf('Symfony\Component\Form\FormError', $errors[0]);
     }

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Helper/EmbedHelperTest.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Helper/EmbedHelperTest.php
@@ -1,6 +1,7 @@
 <?php
+// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Helper;
@@ -8,8 +9,11 @@ namespace ZichtTest\Bundle\FrameworkExtraBundle\Helper;
 use Symfony\Component\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Routing\RouterInterface;
+use Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper;
 use Zicht\Bundle\FrameworkExtraBundle\Url\UrlCheckerService;
 use ZichtTest\Bundle\FrameworkExtraBundle\Tests\AbstractIntegrationTestCase;
 
@@ -20,6 +24,9 @@ class MockType extends Form\AbstractType
         $builder->add('foo', 'text');
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'aForm';
@@ -28,28 +35,29 @@ class MockType extends Form\AbstractType
 
 class MockData
 {
+    /** @var string */
     public $foo = '123';
 }
 
 class EmbedHelperTest extends AbstractIntegrationTestCase
 {
-    /** @var \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper */
+    /** @var EmbedHelper */
     protected $helper;
 
     /** @var SessionInterface */
     protected $session;
 
-    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    /** @var RequestStack */
     protected $request;
 
     /** @var UrlCheckerService */
     protected $urlChecker;
 
-    function setUp()
+    protected function setUp()
     {
-        $this->session = new \Symfony\Component\HttpFoundation\Session\Session(new \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage());
-        $this->request = new \Symfony\Component\HttpFoundation\RequestStack();
-        $request = new \Symfony\Component\HttpFoundation\Request;
+        $this->session = new Session(new MockArraySessionStorage());
+        $this->request = new RequestStack();
+        $request = new Request;
         $request->setSession($this->session);
         $this->request->push($request);
 
@@ -58,7 +66,7 @@ class EmbedHelperTest extends AbstractIntegrationTestCase
 
         $this->router = $this->getMockBuilder('Symfony\Component\Routing\Router')->disableOriginalConstructor()->getMock();
         $this->form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
-        $this->helper = new \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper($this->router, $this->session, $this->request, $this->urlChecker);
+        $this->helper = new EmbedHelper($this->router, $this->session, $this->request, $this->urlChecker);
     }
 
 
@@ -66,16 +74,16 @@ class EmbedHelperTest extends AbstractIntegrationTestCase
      * @covers \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::getEmbedParams
      * @return void
      */
-    function testGetEmbedParams()
+    public function testGetEmbedParams()
     {
         $this->request->getCurrentRequest()->query->set('return_url', 'test 123');
         $this->request->getCurrentRequest()->query->set('success_url', 'test 321');
         $this->assertEquals(
-            array(
+            [
                 'success_url' => 'test 321',
                 'return_url' => 'test 123',
                 'do' => null
-            ),
+            ],
             $this->helper->getEmbedParams()
         );
     }
@@ -85,14 +93,14 @@ class EmbedHelperTest extends AbstractIntegrationTestCase
      * @covers \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::getEmbedParams
      * @return void
      */
-    function testGetEmbedParamsWithoutEmbedParams()
+    public function testGetEmbedParamsWithoutEmbedParams()
     {
         $this->assertEquals(
-            array(
+            [
                 'return_url' => null,
                 'success_url' => null,
                 'do' => null
-            ),
+            ],
             $this->helper->getEmbedParams()
         );
     }
@@ -102,50 +110,50 @@ class EmbedHelperTest extends AbstractIntegrationTestCase
      * @covers \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::url
      * @return void
      */
-    function testUrlGeneration()
+    public function testUrlGeneration()
     {
         $router = $this->createMock(RouterInterface::class);
-        $router->expects($this->once())->method('generate')->with('test', array());
+        $router->expects($this->once())->method('generate')->with('test', []);
         $property = new \ReflectionProperty($this->helper, 'router');
         $property->setAccessible(true);
         $property->setValue($this->helper, $router);
-        $this->helper->url('test', array());
+        $this->helper->url('test', []);
     }
 
     /**
      * @covers \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::url
      * @return void
      */
-    function testUrlGenerationWillInheritEmbedParams()
+    public function testUrlGenerationWillInheritEmbedParams()
     {
         $router = $this->createMock(RouterInterface::class);
-        $router->expects($this->once())->method('generate')->with('test', array('return_url' => 'test 123', 'success_url' => 'test 321'));
+        $router->expects($this->once())->method('generate')->with('test', ['return_url' => 'test 123', 'success_url' => 'test 321']);
         $property = new \ReflectionProperty($this->helper, 'router');
         $property->setAccessible(true);
         $property->setValue($this->helper, $router);
         $this->request->getCurrentRequest()->query->set('return_url', 'test 123');
         $this->request->getCurrentRequest()->query->set('success_url', 'test 321');
-        $this->helper->url('test', array());
+        $this->helper->url('test', []);
     }
 
     /**
      * @covers \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::url
      * @return void
      */
-    function testUrlGenerationCanOverrideEmbedParams()
+    public function testUrlGenerationCanOverrideEmbedParams()
     {
         $router = $this->createMock(RouterInterface::class);
-        $router->expects($this->once())->method('generate')->with('test', array('return_url' => 'override 123', 'success_url' => 'override 321'));
+        $router->expects($this->once())->method('generate')->with('test', ['return_url' => 'override 123', 'success_url' => 'override 321']);
         $property = new \ReflectionProperty($this->helper, 'router');
         $property->setAccessible(true);
         $property->setValue($this->helper, $router);
         $this->request->getCurrentRequest()->query->set('return_url', 'test 123');
         $this->request->getCurrentRequest()->query->set('success_url', 'test 321');
-        $this->helper->url('test', array('return_url' => 'override 123', 'success_url' => 'override 321'));
+        $this->helper->url('test', ['return_url' => 'override 123', 'success_url' => 'override 321']);
     }
 
 
-    function testGetFormId()
+    public function testGetFormId()
     {
         $form = $this->form;
         $this->assertInternalType('string', $this->helper->getFormId($form));

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Tests/AbstractIntegrationTestCase.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Tests/AbstractIntegrationTestCase.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Tests;
@@ -10,7 +10,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 abstract class AbstractIntegrationTestCase extends \PHPUnit_Framework_TestCase
 {
-    static $testParams = array();
+    /** @var array */
+    protected static $testParams = [];
 
     protected function requireTestParams()
     {

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Twig/ExtensionTest.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Twig/ExtensionTest.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Twig;
 
 use Zicht\Bundle\FrameworkExtraBundle\Twig\Extension;
 use Zicht\Util\Str;
 
 /**
- * @covers Zicht\Bundle\FrameworkExtraBundle\Twig\Extension
+ * @covers \Zicht\Bundle\FrameworkExtraBundle\Twig\Extension
  */
 class ExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,9 +30,9 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * @covers Zicht\Bundle\FrameworkExtraBundle\Twig\Extension::getFilters
+     * @covers \Zicht\Bundle\FrameworkExtraBundle\Twig\Extension::getFilters
      */
-    function testAvailableFilters()
+    public function testAvailableFilters()
     {
         $this->getFilter('re_replace');
         $this->getFilter('dump');
@@ -48,64 +49,71 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $filter
+     * @param array $args
+     * @param int|string|array $expect
      * @dataProvider filterData
      */
-    function testFilters($filter, $args, $expect)
+    public function testFilters($filter, $args, $expect)
     {
         $filter = $this->getFilter($filter);
         $this->assertEquals($expect, call_user_func_array($filter->getCallable(), $args));
     }
 
-
-
-    function getFilter($filterName)
+    /**
+     * @param string $filterName
+     * @return \Twig_SimpleFilter
+     */
+    private function getFilter($filterName)
     {
         foreach ($this->extension->getFilters() as $k => $filter) {
-            if ($filter->getName() == $filterName) {
+            if ($filter->getName() === $filterName) {
                 return $filter;
             }
         }
         throw new \OutOfBoundsException("{$filterName} not found");
     }
 
+    /**
+     * @return array[]
+     */
+    public function filterData()
+    {
+        return [
+            ['re_replace', ['ab', '/.b/', 'c'], 'c'],
+            ['str_uscore', ['abcDef'], Str::uscore('abcDef')],
+            ['str_uscore', ['abc def'], Str::uscore('abc def')],
+            ['str_dash', ['abcDef'], Str::dash('abcDef')],
+            ['str_dash', ['abc def'], Str::dash('abc def')],
+            ['relative_date', [new \DateTime('-10 seconds -2 minutes')], '2 minutes ago'],
+            ['relative_date', [new \DateTime('-1 hour')], '1 hour ago'],
+            ['date_format', [new \DateTime(), 'ymd'], 'ymd'],
+            ['date_format', [new \DateTime(), '%Y-%m-%d'], strftime('%Y-%m-%d')],
+            ['floor', [1.9], 1],
+            ['floor', [1.1], 1],
+            ['ceil', [1.1], 2],
+            ['ceil', [1.8], 2],
+            ['url_to_form_params', [''], []],
+            ['url_to_form_params', ['/'], []],
+            ['url_to_form_params', ['/?'], []],
+            ['url_to_form_params', ['/?a'], ['a' => '']], //< --- this is intended behaviour
+            ['url_to_form_params', ['/?a=b'], ['a' => 'b']],
+            ['url_to_form_params', ['/?a[x][y]=b'], ['a[x][y]' => 'b']],
+            ['url_to_form_params', ['/?a[x][y]=b&c=1'], ['a[x][y]' => 'b', 'c' => '1']],
+            ['url_to_form_params', ['/?a[x][y]=b&a[x][z]=c'], ['a[x][y]' => 'b', 'a[x][z]' => 'c']],
 
-
-    function filterData() {
-        return array(
-            array('re_replace', array('ab', '/.b/', 'c'), 'c'),
-            array('str_uscore', array('abcDef'), Str::uscore('abcDef')),
-            array('str_uscore', array('abc def'), Str::uscore('abc def')),
-            array('str_dash', array('abcDef'), Str::dash('abcDef')),
-            array('str_dash', array('abc def'), Str::dash('abc def')),
-            array('relative_date', array(new \DateTime('-10 seconds -2 minutes')), '2 minutes ago'),
-            array('relative_date', array(new \DateTime('-1 hour')), '1 hour ago'),
-            array('date_format', array(new \DateTime(), 'ymd'), 'ymd'),
-            array('date_format', array(new \DateTime(), '%Y-%m-%d'), strftime('%Y-%m-%d')),
-            array('floor', array(1.9), 1),
-            array('floor', array(1.1), 1),
-            array('ceil', array(1.1), 2),
-            array('ceil', array(1.8), 2),
-            array('url_to_form_params', array(''), array()),
-            array('url_to_form_params', array('/'), array()),
-            array('url_to_form_params', array('/?'), array()),
-            array('url_to_form_params', array('/?a'), array('a' => '')), //< --- this is intended behaviour
-            array('url_to_form_params', array('/?a=b'), array('a' => 'b')),
-            array('url_to_form_params', array('/?a[x][y]=b'), array('a[x][y]' => 'b')),
-            array('url_to_form_params', array('/?a[x][y]=b&c=1'), array('a[x][y]' => 'b', 'c' => '1')),
-            array('url_to_form_params', array('/?a[x][y]=b&a[x][z]=c'), array('a[x][y]' => 'b', 'a[x][z]' => 'c')),
-
-            array('url_strip_query', array(''), ''),
-            array('url_strip_query', array('/'), '/'),
-            array('url_strip_query', array('/?'), '/'),
-            array('url_strip_query', array('/?a'), '/'),
-            array('url_strip_query', array('/?a=b'), '/'),
-            array('url_strip_query', array('/?a[x][y]=b'), '/'),
-            array('url_strip_query', array('/?a[x][y]=b&c=1'), '/'),
-            array('url_strip_query', array('/?a[x][y]=b&a[x][z]=c'), '/'),
-            array('url_strip_query', array('http://www.example.org/some/path/with=values?a[x][y]=b&a[x][z]=c'), 'http://www.example.org/some/path/with=values'),
-            array('url_strip_query', array('https://www.example.org/some/path/with=values?a[x][y]=b&a[x][z]=c'), 'https://www.example.org/some/path/with=values'),
-            array('url_strip_query', array('https://www.example.com/some/path/with=values#note_that_the_hash_should_remain'), 'https://www.example.com/some/path/with=values#note_that_the_hash_should_remain'),
-            array('url_strip_query', array('https://www.example.com/some/path/with=values?a[x][y]=b&a[x][z]=c#note_that_the_hash_should_remain'), 'https://www.example.com/some/path/with=values#note_that_the_hash_should_remain'),
-        );
+            ['url_strip_query', [''], ''],
+            ['url_strip_query', ['/'], '/'],
+            ['url_strip_query', ['/?'], '/'],
+            ['url_strip_query', ['/?a'], '/'],
+            ['url_strip_query', ['/?a=b'], '/'],
+            ['url_strip_query', ['/?a[x][y]=b'], '/'],
+            ['url_strip_query', ['/?a[x][y]=b&c=1'], '/'],
+            ['url_strip_query', ['/?a[x][y]=b&a[x][z]=c'], '/'],
+            ['url_strip_query', ['http://www.example.org/some/path/with=values?a[x][y]=b&a[x][z]=c'], 'http://www.example.org/some/path/with=values'],
+            ['url_strip_query', ['https://www.example.org/some/path/with=values?a[x][y]=b&a[x][z]=c'], 'https://www.example.org/some/path/with=values'],
+            ['url_strip_query', ['https://www.example.com/some/path/with=values#note_that_the_hash_should_remain'], 'https://www.example.com/some/path/with=values#note_that_the_hash_should_remain'],
+            ['url_strip_query', ['https://www.example.com/some/path/with=values?a[x][y]=b&a[x][z]=c#note_that_the_hash_should_remain'], 'https://www.example.com/some/path/with=values#note_that_the_hash_should_remain'],
+        ];
     }
 }

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Url/UrlCheckerServiceTest.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Url/UrlCheckerServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Url;
@@ -69,7 +69,7 @@ class UrlCheckerServiceTest extends \PHPUnit_Framework_TestCase
                     'zicht.nl',
                     'www.zicht.nl',
                     'foo.zicht.nl',
-                    'a-foo.zicht.nl'
+                    'a-foo.zicht.nl',
                 ],
                 'urls' => [
                     '/',

--- a/tests/ZichtTest/Bundle/FrameworkExtraBundle/Util/SortedListTest.php
+++ b/tests/ZichtTest/Bundle/FrameworkExtraBundle/Util/SortedListTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Util;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,9 @@
 <?php
 
-if (!is_dir(__DIR__.'/../vendor/')) {
+if (!is_dir(__DIR__ . '/../vendor/')) {
     die('Vendors not installed. Have you tried "composer.phar install"?' . "\n");
 }
 
-$loader = require __DIR__.'/../vendor/autoload.php';
+$loader = require __DIR__ . '/../vendor/autoload.php';
 
 return $loader;


### PR DESCRIPTION
- Fixing linting errors
- Fixing composer.json (psr-4 autoloaders, dependencies)
- Removing deprecated method getName() in form types
- Fixed maintainers
- Added Docker compose file

Ik heb em ook even getest in een project d.m.v. `composer require 'zicht/framework-extra-bundle:dev-fix/cleanups as 8.2.0'`