### PR TITLE
Fixed EmbedHelper::handleForm() Docblock types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed \Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::handleForm() Docblock types
 ### Added|Changed|Deprecated|Removed|Fixed|Security
-Nothing so far
+Nothing else so far
 
 ## 9.3.1 - 2021-08-27
 ### Added

--- a/src/Helper/EmbedHelper.php
+++ b/src/Helper/EmbedHelper.php
@@ -173,12 +173,12 @@ class EmbedHelper
      * The return value is either a Response object that can be returned as the result of the action, or it is an
      * array which can be used in a template.
      *
-     * @param Form $form
-     * @param \callback $handlerCallback
+     * @param Form|FormInterface $form
+     * @param callable $handlerCallback
      * @param string $formTargetRoute
      * @param array $formTargetParams
      * @param array $extraViewVars
-     * @param null|\callable $formIdHandler
+     * @param null|callable $formIdHandler
      * @return array|Response
      * @throws \Exception
      */


### PR DESCRIPTION
Getting errors/warnings from toolings:

- When type hinting FormInterface in project code, I get a warning on EmbedHelper handleForm first argument:
  > Expected parameter of type '\Symfony\Component\Form\Form', '\Symfony\Component\Form\FormInterface' provided 

- When passing in a typical `function (FormInterface $form) { ... }` as second argument of  EmbedHelper handleForm, I get an error:
  > InvalidArgument - Argument 2 of EmbedHelper::handleForm expects callback, Closure(FormInterface) provided

  The type `\callback` doesn't exists. It probably assumes a root level class "callback". The correct type is `callable`.

For this last issue I've temporarily put into my psalm.xml config:

```xml
<psalm>
    <issueHandlers>
        <InvalidArgument>
            <errorLevel type="suppress">
                <referencedFunction name="Zicht\Bundle\FrameworkExtraBundle\Helper\EmbedHelper::handleForm"/>
            </errorLevel>
        </InvalidArgument>
    </issueHandlers>
</psalm>
```