### PR TITLE
Upgrade to phpunit 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 9.3.4 - 2021-11-17
+### Changed
+- Upgraded to phpunit 7.
+
 ## 9.3.3 - 2021-10-25
 ### Fixed
 - Passing a `null` to `method_exists` is deprecated and will break in PHP 8.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "zicht/util": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^7",
         "zicht/standards-php": "^4"
     },
     "autoload": {

--- a/tests/Fixture/BuilderTest.php
+++ b/tests/Fixture/BuilderTest.php
@@ -6,9 +6,10 @@
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Fixture {
 
+    use PHPUnit\Framework\TestCase;
     use Zicht\Bundle\FrameworkExtraBundle\Fixture\Builder;
 
-    class BuilderTest extends \PHPUnit_Framework_TestCase
+    class BuilderTest extends TestCase
     {
         public $builder;
 

--- a/tests/JsonSchema/SchemaServiceTest.php
+++ b/tests/JsonSchema/SchemaServiceTest.php
@@ -5,11 +5,12 @@
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\JsonSchema;
 
+use PHPUnit\Framework\TestCase;
 use Swaggest\JsonSchema\Schema;
 use Symfony\Component\Translation\TranslatorInterface;
 use Zicht\Bundle\FrameworkExtraBundle\JsonSchema\SchemaService;
 
-class SchemaServiceTest extends \PHPUnit_Framework_TestCase
+class SchemaServiceTest extends TestCase
 {
     /** @var SchemaService */
     protected $schemaService = null;

--- a/tests/Tests/AbstractIntegrationTestCase.php
+++ b/tests/Tests/AbstractIntegrationTestCase.php
@@ -5,10 +5,11 @@
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-abstract class AbstractIntegrationTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractIntegrationTestCase extends TestCase
 {
     /** @var array */
     protected static $testParams = [];

--- a/tests/Twig/ExtensionTest.php
+++ b/tests/Twig/ExtensionTest.php
@@ -5,13 +5,14 @@
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Twig;
 
+use PHPUnit\Framework\TestCase;
 use Zicht\Bundle\FrameworkExtraBundle\Twig\Extension;
 use Zicht\Util\Str;
 
 /**
  * @covers \Zicht\Bundle\FrameworkExtraBundle\Twig\Extension
  */
-class ExtensionTest extends \PHPUnit_Framework_TestCase
+class ExtensionTest extends TestCase
 {
     /**
      * @var \Twig_Extension

--- a/tests/Url/UrlCheckerServiceTest.php
+++ b/tests/Url/UrlCheckerServiceTest.php
@@ -5,11 +5,12 @@
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Url;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Zicht\Bundle\FrameworkExtraBundle\Url\UrlCheckerService;
 
-class UrlCheckerServiceTest extends \PHPUnit_Framework_TestCase
+class UrlCheckerServiceTest extends TestCase
 {
     public function testEmptyUrlIsUnsafe()
     {

--- a/tests/Util/SortedListTest.php
+++ b/tests/Util/SortedListTest.php
@@ -5,9 +5,10 @@
 
 namespace ZichtTest\Bundle\FrameworkExtraBundle\Util;
 
+use PHPUnit\Framework\TestCase;
 use Zicht\Bundle\FrameworkExtraBundle\Util\SortedList;
 
-class SortedListTest extends \PHPUnit_Framework_TestCase
+class SortedListTest extends TestCase
 {
     /**
      * Test handling of priorities by SortedList.


### PR DESCRIPTION
Een hogere versie van `phpunit/phpunit` is in principe beschikbaar, maar functioneert pas bij expliciete PHP-versie 7.1 en dat zou huidige projecten kunnen breken die daarop draaien in combinatie met deze bundel.