### PR TITLE
Added `'choice_translation_domain' => false` to ParentChoiceType. Choice labels do not need translation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 9.4.2 - 2022-09-26
+### Fixed
+- Added `'choice_translation_domain' => false` to ParentChoiceType. Choice labels do not need translation.
+
 ## 9.4.1 - 2022-05-16
 ### Fixed
 - Fixed Pageable interface types

--- a/src/Form/ParentChoiceType.php
+++ b/src/Form/ParentChoiceType.php
@@ -81,7 +81,7 @@ class ParentChoiceType extends AbstractType
                 'parent',
                 ChoiceType::class,
                 $parentId,
-                ['choices' => array_flip($choices), 'mapped' => false, 'auto_initialize' => false]
+                ['choices' => array_flip($choices), 'mapped' => false, 'auto_initialize' => false, 'choice_translation_domain' => false]
             );
         };
 


### PR DESCRIPTION
Getting missing messages reports because of this. Labels for these options do not need translation, because they come from entities (from the DB).

![Screenshot from 2022-09-26 16-29-31](https://user-images.githubusercontent.com/2794908/192303018-69849aed-6c0a-4dff-bc45-68a4581a8468.png)
