### PR TITLE
Add FC for Twig TokenParserInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 10.0.2 - 2022-11-16
+### Added
+- Forward compatibility for `TokenParserInterface`.
+
 ## 10.0.1 - 2022-11-14
 ### Removed
 - Removed several console commands due to inactive use

--- a/src/Twig/ControlStructures/StrictTokenParser.php
+++ b/src/Twig/ControlStructures/StrictTokenParser.php
@@ -5,6 +5,7 @@
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
 
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -13,18 +14,12 @@ use Twig\TokenParser\AbstractTokenParser;
  */
 class StrictTokenParser extends AbstractTokenParser
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function getTag()
+    public function getTag(): string
     {
         return 'strict';
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $lineno = $token->getLine();
 

--- a/src/Twig/ControlStructures/SwitchTokenParser.php
+++ b/src/Twig/ControlStructures/SwitchTokenParser.php
@@ -12,18 +12,12 @@ use Twig\TokenParser\AbstractTokenParser;
 
 class SwitchTokenParser extends AbstractTokenParser
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function getTag()
+    public function getTag(): string
     {
         return 'switch';
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $lineno = $token->getLine();
 

--- a/src/Twig/ControlStructures/WithTokenParser.php
+++ b/src/Twig/ControlStructures/WithTokenParser.php
@@ -5,6 +5,7 @@
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures;
 
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -24,22 +25,15 @@ class WithTokenParser extends AbstractTokenParser
         'always',
     ];
 
-    /**
-     * Gets the tag name associated with this token parser.
-     *
-     * @return string
-     */
-    public function getTag()
+    public function getTag(): string
     {
         return 'with';
     }
 
     /**
-     * Parses a token and returns a node.
-     *
      * @return WithNode
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $options = [];
         $stream = $this->parser->getStream();

--- a/src/Twig/Meta/AnnotateTokenParser.php
+++ b/src/Twig/Meta/AnnotateTokenParser.php
@@ -5,19 +5,16 @@
 
 namespace Zicht\Bundle\FrameworkExtraBundle\Twig\Meta;
 
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
 class AnnotateTokenParser extends AbstractTokenParser
 {
     /**
-     * Parses a token and returns a node.
-     *
-     * @param Token $token A Token instance
-     *
-     * @return AnnotateNode A Twig_NodeInterface instance
+     * @return AnnotateNode
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
 
@@ -40,12 +37,7 @@ class AnnotateTokenParser extends AbstractTokenParser
         return $node;
     }
 
-    /**
-     * Gets the tag name associated with this token parser.
-     *
-     * @return string The tag name
-     */
-    public function getTag()
+    public function getTag(): string
     {
         return 'annotate';
     }

--- a/src/Twig/Meta/AnnotationsTokenParser.php
+++ b/src/Twig/Meta/AnnotationsTokenParser.php
@@ -12,13 +12,9 @@ use Twig\TokenParser\AbstractTokenParser;
 class AnnotationsTokenParser extends AbstractTokenParser
 {
     /**
-     * Parses a token and returns a node.
-     *
-     * @param Token $token A Token instance
-     *
      * @return AnnotationsNode A Twig_NodeInterface instance
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
 
@@ -30,12 +26,7 @@ class AnnotationsTokenParser extends AbstractTokenParser
         return new AnnotationsNode(['body' => $body]);
     }
 
-    /**
-     * Gets the tag name associated with this token parser.
-     *
-     * @return string The tag name
-     */
-    public function getTag()
+    public function getTag(): string
     {
         return 'annotations';
     }


### PR DESCRIPTION
```Method "Twig\TokenParser\TokenParserInterface::getTag()" might add "string" as a native return type declaration in the future. Do the same in implementation "Zicht\Bundle\FrameworkExtraBundle\Twig\ControlStructures\StrictTokenParser" now to avoid errors or add an explicit @return annotation to suppress this message.```